### PR TITLE
instructions for running test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ Contributions for integrations with other projects are appreciated!
 
 [bundle]: src/Broadway/Bundle/BroadwayBundle/
 
+## Testing
+
+To runs the test suite, first ensure you have phpunit installed on your system:
+
+```
+$ composer global require "phpunit/phpunit=4.1.*"
+```
+
+Make sure you have `~/.composer/vendor/bin/` in your path, then run:
+
+```
+$ phpunit
+```
+
 ## Acknowledgements
 
 The broadway project is heavily inspired by other open source project such as

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
       }
     ],
     "require-dev": {
-        "phpunit/phpunit": "~4.2",
         "doctrine/dbal": "~2.4",
         "doctrine/mongodb": "~1.0",
         "elasticsearch/elasticsearch": "~1.0",

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
-if (!file_exists($file = __DIR__.'/../vendor/autoload.php')) {
-    throw new RuntimeException('Install dependencies and run "composer dumpautoload" to run test suite.');
+if (file_exists($file = __DIR__.'/../vendor/autoload.php')) {
+    require_once $file;
+} else {
+    throw new RuntimeException('Install dependencies to run test suite.');
 }


### PR DESCRIPTION
Changed require_once call to require; since phpunit autoloads composer, the require_once call was returning `true` as in _this file has already been required_.
