### PR TITLE
Scenario should allow for setting arbitrary ID for given events.

### DIFF
--- a/src/Broadway/CommandHandling/Testing/Scenario.php
+++ b/src/Broadway/CommandHandling/Testing/Scenario.php
@@ -58,7 +58,6 @@ class Scenario
 
     /**
      * @param array $events
-     * @param string $id
      *
      * @return Scenario
      */


### PR DESCRIPTION
Here is my use case:

``` php
    /**
     * @test
     */
    public function it_should_suspend()
    {
        $userId = UserId::generate();

        $this->scenario
            ->given([UserWasRegistered::with($userId, new Person)], $userId)
            ->when(SuspendUser::with($userId))
            ->then([
                UserWasSuspended::with($userId),
            ]);
    }
```

Without being able to specify an ID for the given() events, I was getting an error from the event store saying that no stream could be found for the given ID.

There was already notes in the class saying that maybe hardcoding the ID to 1 wasn't all that good of an idea. :)

> // todo: the hardcoded ID is probably wrong....

It might be more consistent to **not** have a default ID and to require the aggregate root ID to be the first argument instead. I implemented it this way first as it would be minimal impact on existing code and as a proof of concept.
