### PR TITLE
ID can also be an object that implements __toString

### DIFF
--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -59,7 +59,7 @@ class DBALEventStore implements EventStoreInterface
     public function load($id)
     {
         $statement = $this->prepareLoadStatement();
-        $statement->bindValue('uuid', $id, 'guid');
+        $statement->bindValue('uuid', (string) $id, 'guid');
         $statement->execute();
 
         $events = array();
@@ -79,6 +79,13 @@ class DBALEventStore implements EventStoreInterface
      */
     public function append($id, DomainEventStreamInterface $eventStream)
     {
+        // noop to ensure that an error will be thrown early if the ID
+        // is not something that can be converted to a string. If we
+        // let this move on without doing this DBAL will eventually
+        // give us a hard time but the true reason for the problem
+        // will be obfuscated.
+        $id = (string) $id;
+
         $this->connection->beginTransaction();
 
         try {

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -28,6 +28,8 @@ class InMemoryEventStore implements EventStoreInterface
      */
     public function load($id)
     {
+        $id = (string) $id;
+
         if (isset($this->events[$id])) {
             return new DomainEventStream($this->events[$id]);
         }
@@ -40,6 +42,8 @@ class InMemoryEventStore implements EventStoreInterface
      */
     public function append($id, DomainEventStreamInterface $eventStream)
     {
+        $id = (string) $id;
+
         if (! isset($this->events[$id])) {
             $this->events[$id] = array();
         }


### PR DESCRIPTION
Here is my use case:

``` php
    /**
     * @test
     */
    public function it_should_suspend()
    {
        $userId = UserId::generate();

        $this->scenario
            ->given([UserWasRegistered::with($userId, new Person)], $userId)
            ->when(SuspendUser::with($userId))
            ->then([
                UserWasSuspended::with($userId),
            ]);
    }
```

This is loosely related to #18 in that I ran into both of these problems more or less at the same time. Since my ID is an object I was going to have to do a lot of `(string) $id` in a lot of weird places and it was becoming unmanageable.

The issues were mainly around the fact that the `InMemoryEventStore` were using `$id` raw and assuming it was a stringish looking thing. I made changes to `DBALEventStore` to keep it consistent.

There should be a test to make sure this functionality continues to work but I wanted to make sure I'm on the right track here first. All of my domain models have an actual value object to represent their ID so this is going to be a big deal for me to have to change if I cannot pass the ID as-is in many places.
