### PR TITLE
Avoid calling public constructor.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "beberlei/assert": "~1.6",
         "php": ">=5.3.3",
-        "rhumsaa/uuid": "~2.4"
+        "rhumsaa/uuid": "~2.4",
+        "doctrine/instantiator": "~1.0,>=1.0.2"
     },
     "authors": [
       {

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -20,6 +20,7 @@ use Broadway\EventStore\EventStoreInterface;
 use Broadway\EventStore\EventStreamNotFoundException;
 use Broadway\Repository\AggregateNotFoundException;
 use Broadway\Repository\RepositoryInterface;
+use Doctrine\Instantiator\Instantiator;
 
 /**
  * Naive initial implementation of an event sourced aggregate repository.
@@ -29,6 +30,8 @@ class EventSourcingRepository implements RepositoryInterface
     private $eventStore;
     private $eventBus;
     private $aggregateClass;
+    private $eventStreamDecorators:
+    private $instantiator;
 
     /**
      * @param string $aggregateClass
@@ -45,6 +48,7 @@ class EventSourcingRepository implements RepositoryInterface
         $this->eventBus              = $eventBus;
         $this->aggregateClass        = $aggregateClass; // todo: aggregate factory
         $this->eventStreamDecorators = $eventStreamDecorators;
+        $this->instantiator          = new Instantiator();
     }
 
     /**
@@ -55,7 +59,7 @@ class EventSourcingRepository implements RepositoryInterface
         try {
             $domainEventStream = $this->eventStore->load($id);
 
-            $aggregate = new $this->aggregateClass();
+            $aggregate = $this->instantiator->instantiate($this->aggregateClass);
             $aggregate->initializeState($domainEventStream);
 
             return $aggregate;


### PR DESCRIPTION
This is an alternative to #27 as suggested by @stof. It adds a new dependency which I was hoping to avoid but this is probably safer.
