### PR TITLE
EventSourcedAggregateRoots should have the capability to instantiate themselves.

### DIFF
--- a/src/Broadway/EventSourcing/AggregateFactory/AggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/AggregateFactory.php
@@ -1,0 +1,16 @@
+<?php namespace Broadway\EventSourcing\AggregateFactory;
+
+use Broadway\Domain\DomainEventStreamInterface;
+
+/**
+ * Interface AggregateFactory
+ */
+interface AggregateFactory
+{
+    /**
+     * @param string $aggregateClass the FQCN of the Aggregate to create
+     * @param DomainEventStreamInterface $domainEventStream
+     * @return \Broadway\EventSourcing\EventSourcedAggregateRoot
+     */
+    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream);
+}

--- a/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
@@ -1,0 +1,19 @@
+<?php namespace Broadway\EventSourcing\AggregateFactory;
+
+use Broadway\Domain\DomainEventStreamInterface;
+
+/**
+ * Creates aggregates by instantiating the aggregateClass and then
+ * passing a DomainEventStream to the public initializeState() method.
+ * E.g. (new \Vendor\AggregateRoot)->initializeState($domainEventStream);
+ */
+class PublicConstructorAggregateFactory implements AggregateFactory
+{
+    /** {@inheritDoc} */
+    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream)
+    {
+        $aggregate = new $aggregateClass;
+        $aggregate->initializeState($domainEventStream);
+        return $aggregate;
+    }
+}

--- a/src/Broadway/EventSourcing/AggregateFactory/StaticConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/StaticConstructorAggregateFactory.php
@@ -1,0 +1,35 @@
+<?php namespace Broadway\EventSourcing\AggregateFactory;
+
+use Assert\Assertion as Assert;
+use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+
+/**
+ * Creates aggregates by passing a DomainEventStream to the given public static method
+ * which is itself responsible for returning an instance of itself.
+ * E.g. (\Vendor\AggregateRoot::instantiateForReconstitution())->initializeState($domainEventStream);
+ */
+class StaticConstructorAggregateFactory implements AggregateFactory
+{
+    /** @var string the name of the method to call on the Aggregate */
+    private $staticConstructorMethod;
+
+    public function __construct($staticConstructorMethod = 'instantiateForReconstitution')
+    {
+        $this->staticConstructorMethod = $staticConstructorMethod;
+    }
+
+    /** {@inheritDoc} */
+    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream)
+    {
+        Assert::true(method_exists($aggregateClass, $this->staticConstructorMethod));
+
+        $methodCall = sprintf('%s::%s', $aggregateClass, $this->staticConstructorMethod);
+        $aggregate = call_user_func($methodCall);
+
+        Assert::isInstanceOf($aggregate, $aggregateClass);
+
+        $aggregate->initializeState($domainEventStream);
+        return $aggregate;
+    }
+}

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -59,41 +59,9 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
     }
 
     /**
-     * Reconstitute the aggregate from an event stream.
-     *
-     * @return EventSourcedAggregateRoot
-     */
-    public static function reconstituteFromDomainEventStream(DomainEventStream $stream)
-    {
-        $instance = static::instantiateForReconstitution();
-
-        $instance->initializeState($stream);
-
-        return $instance;
-    }
-
-    /**
-     * Used to instantiate an aggregate for the purpose of reconstitution.
-     *
-     * The default implementation will allow for calling an empty constructor.
-     * This will currently work on any EventSourcedAggregateRoot class that has
-     * no constructor, a public constructor, or a protected constructor.
-     *
-     * If an EventSourcedAggregateRoot has a private constructor the
-     * EventSourcedAggregateRoot should override this method and call the
-     * private constructor itself.
-     *
-     * @return EventSourcedAggregateRoot
-     */
-    protected static function instantiateForReconstitution()
-    {
-        return new static;
-    }
-
-    /**
      * Initializes the aggregate using the given "history" of events.
      */
-    protected function initializeState(DomainEventStream $stream)
+    public function initializeState(DomainEventStream $stream)
     {
         foreach ($stream as $message) {
             $this->playhead++;

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -16,6 +16,8 @@ use Assert\InvalidArgumentException;
 use Broadway\Domain\AggregateRoot;
 use Broadway\Domain\DomainEventStream;
 use Broadway\EventHandling\EventBusInterface;
+use Broadway\EventSourcing\AggregateFactory\AggregateFactory;
+use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
 use Broadway\EventStore\EventStoreInterface;
 use Broadway\EventStore\EventStreamNotFoundException;
 use Broadway\Repository\AggregateNotFoundException;
@@ -29,22 +31,32 @@ class EventSourcingRepository implements RepositoryInterface
     private $eventStore;
     private $eventBus;
     private $aggregateClass;
+    private $aggregateFactory;
 
     /**
-     * @param string $aggregateClass
+     * @param EventStoreInterface $eventStore
+     * @param EventBusInterface $eventBus
+     * @param $aggregateClass
+     * @param array $eventStreamDecorators
+     * @param AggregateFactory $aggregateFactory
      */
     public function __construct(
         EventStoreInterface $eventStore,
         EventBusInterface $eventBus,
         $aggregateClass,
-        array $eventStreamDecorators = array()
+        array $eventStreamDecorators = array(),
+        AggregateFactory $aggregateFactory = null
     ) {
         $this->assertExtendsEventSourcedAggregateRoot($aggregateClass);
 
         $this->eventStore            = $eventStore;
         $this->eventBus              = $eventBus;
-        $this->aggregateClass        = $aggregateClass; // todo: aggregate factory
+        $this->aggregateClass        = $aggregateClass;
         $this->eventStreamDecorators = $eventStreamDecorators;
+        if (is_null($aggregateFactory)) {
+            $aggregateFactory = new PublicConstructorAggregateFactory();
+        }
+        $this->aggregateFactory = $aggregateFactory;
     }
 
     /**
@@ -54,10 +66,7 @@ class EventSourcingRepository implements RepositoryInterface
     {
         try {
             $domainEventStream = $this->eventStore->load($id);
-
-            $aggregateClass = new $this->aggregateClass();
-
-            return $aggregateClass::reconstituteFromDomainEventStream($domainEventStream);
+            return $this->aggregateFactory->create($this->aggregateClass, $domainEventStream);
         } catch (EventStreamNotFoundException $e) {
             throw AggregateNotFoundException::create($id, $e);
         }

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -17,12 +17,14 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventHandling\SimpleEventBus;
 use Broadway\EventHandling\TraceableEventBus;
+use Broadway\EventStore\EventStoreInterface;
 use Broadway\EventStore\InMemoryEventStore;
 use Broadway\EventStore\TraceableEventStore;
 use Broadway\TestCase;
 
 abstract class AbstractEventSourcingRepositoryTest extends TestCase
 {
+    /** @var EventStoreInterface */
     protected $eventStore;
 
     public function setUp()

--- a/test/Broadway/EventSourcing/EventSourcedAggregateRootTest.php
+++ b/test/Broadway/EventSourcing/EventSourcedAggregateRootTest.php
@@ -42,9 +42,8 @@ class EventSourcedAggregateRootTest extends TestCase
      */
     public function initialize_state_should_set_internal_playhead()
     {
-        $aggregateRoot = MyTestAggregateRoot::reconstituteFromDomainEventStream(
-            $this->toDomainEventStream(array(new AggregateEvent()))
-        );
+        $aggregateRoot = new MyTestAggregateRoot;
+        $aggregateRoot->initializeState($this->toDomainEventStream(array(new AggregateEvent())));
 
         $aggregateRoot->apply(new AggregateEvent());
 
@@ -59,35 +58,10 @@ class EventSourcedAggregateRootTest extends TestCase
      */
     public function apply_should_call_the_apply_for_specific_event()
     {
-        $aggregateRoot = MyTestAggregateRoot::reconstituteFromDomainEventStream(
-            $this->toDomainEventStream(array(new AggregateEvent()))
-        );
+        $aggregateRoot = new MyTestAggregateRoot;
+        $aggregateRoot->initializeState($this->toDomainEventStream(array(new AggregateEvent())));
 
         $this->assertTrue($aggregateRoot->isCalled);
-    }
-
-    /**
-     * @test
-     */
-    public function protected_constructors_should_be_called()
-    {
-        $aggregateRoot = MyTestAggregateRootWithProtectedConstructor::reconstituteFromDomainEventStream(
-            $this->toDomainEventStream(array())
-        );
-
-        $this->assertTrue($aggregateRoot->constructorWasCalled);
-    }
-
-    /**
-     * @test
-     */
-    public function private_constructors_should_be_called()
-    {
-        $aggregateRoot = MyTestAggregateRootWithPrivateConstructor::reconstituteFromDomainEventStream(
-            $this->toDomainEventStream(array())
-        );
-
-        $this->assertTrue($aggregateRoot->constructorWasCalled);
     }
 
     private function toDomainEventStream(array $events)
@@ -115,41 +89,6 @@ class MyTestAggregateRoot extends EventSourcedAggregateRoot
     public function applyAggregateEvent($event)
     {
         $this->isCalled = true;
-    }
-}
-
-class MyTestAggregateRootWithProtectedConstructor extends EventSourcedAggregateRoot
-{
-    public $constructorWasCalled = false;
-
-    protected function __construct()
-    {
-        $this->constructorWasCalled = true;
-    }
-
-    public function getId()
-    {
-        return 'y0l0';
-    }
-}
-
-class MyTestAggregateRootWithPrivateConstructor extends EventSourcedAggregateRoot
-{
-    public $constructorWasCalled = false;
-
-    private function __construct()
-    {
-        $this->constructorWasCalled = true;
-    }
-
-    public function getId()
-    {
-        return 'y0l0';
-    }
-
-    protected static function instantiateForReconstitution()
-    {
-        return new static();
     }
 }
 

--- a/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
@@ -11,7 +11,11 @@
 
 namespace Broadway\EventSourcing;
 
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
 use Broadway\EventHandling\TraceableEventBus;
+use Broadway\EventSourcing\AggregateFactory\StaticConstructorAggregateFactory;
 use Broadway\EventStore\TraceableEventStore;
 
 class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
@@ -34,6 +38,61 @@ class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
     {
         new EventSourcingRepository($this->eventStore, $this->eventBus, 'stdClass');
     }
+
+    /**
+     * @test
+     */
+    public function it_can_use_an_alternative_AggregateFactory_to_create_the_Aggregate()
+    {
+        // make sure events exist in the event store
+        $id = 'y0l0';
+        $this->eventStore->append($id, new DomainEventStream(array(
+            DomainMessage::recordNow(42, 0, new Metadata(array()), new DidEvent)
+        )));
+
+        $repository = $this->repositoryWithStaticAggregateFactory();
+        $aggregate = $repository->load('y0l0');
+        $this->assertTrue($aggregate->constructorWasCalled);
+        $this->assertEquals($aggregate->instantiatedThrough, 'instantiateForReconstitution');
+
+        $repository = $this->repositoryWithStaticAggregateFactory('justAnotherInstantiation');
+        $aggregate = $repository->load('y0l0');
+        $this->assertTrue($aggregate->constructorWasCalled);
+        $this->assertEquals($aggregate->instantiatedThrough, 'justAnotherInstantiation');
+    }
+
+    /**
+     * @test
+     * @expectedException \Assert\InvalidArgumentException
+     */
+    public function it_throws_an_exception_if_the_static_method_does_not_exist()
+    {
+        // make sure events exist in the event store
+        $id = 'y0l0';
+        $this->eventStore->append($id, new DomainEventStream(array(
+            DomainMessage::recordNow(42, 0, new Metadata(array()), new DidEvent)
+        )));
+
+        $repository = $this->repositoryWithStaticAggregateFactory('someUnknownStaticmethod');
+        $repository->load('y0l0');
+    }
+
+    protected function repositoryWithStaticAggregateFactory($staticMethod = null)
+    {
+        if (is_null($staticMethod)) {
+            $staticFactory = new StaticConstructorAggregateFactory();
+        } else {
+            $staticFactory = new StaticConstructorAggregateFactory($staticMethod);
+        }
+
+        return new EventSourcingRepository(
+            $this->eventStore,
+            $this->eventBus,
+            '\Broadway\EventSourcing\TestEventSourcedAggregateWithStaticConstructor',
+            array(),
+            $staticFactory
+        );
+    }
 }
 
 class TestEventSourcedAggregate extends EventSourcedAggregateRoot
@@ -49,4 +108,36 @@ class TestEventSourcedAggregate extends EventSourcedAggregateRoot
     {
         $this->numbers[] = $event->number;
     }
+}
+
+
+class TestEventSourcedAggregateWithStaticConstructor extends EventSourcedAggregateRoot
+{
+    public $constructorWasCalled = false;
+    public $instantiatedThrough;
+
+    private function __construct($instantiatedThrough)
+    {
+        $this->constructorWasCalled = true;
+        $this->instantiatedThrough = $instantiatedThrough;
+    }
+
+    public function getId()
+    {
+        return 'y0l0';
+    }
+
+    public static function instantiateForReconstitution()
+    {
+        return new TestEventSourcedAggregateWithStaticConstructor(__FUNCTION__);
+    }
+
+    public static function justAnotherInstantiation()
+    {
+        return new TestEventSourcedAggregateWithStaticConstructor(__FUNCTION__);
+    }
+}
+
+class DidEvent
+{
 }


### PR DESCRIPTION
Yet another pass at aggregate root instantiation. This method was mentioned in #28.

This comes pretty close to allowing for private constructors out of the box except that it is really only easily possible if we were doing things as a trait. However, protected constructors will help a lot so I think I'm fine what that.

Supporting private constructors and custom instantiation (arguments to the constructor, for example) are possible provided that the aggregate root overrides `instantiateForReconstitution`.

I'm up for renaming any of these things if it makes it easier. I borrowed the "reconstitute" naming from Event Centric.
