### PR TITLE
fix getUncommittedEvents being used to also clear the uncomitted events

### DIFF
--- a/src/Broadway/Domain/AggregateRoot.php
+++ b/src/Broadway/Domain/AggregateRoot.php
@@ -22,6 +22,11 @@ interface AggregateRoot
     public function getUncommittedEvents();
 
     /**
+     * @return void
+     */
+    public function clearUncommittedEvents();
+
+    /**
      * @return string
      */
     public function getId();

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -51,11 +51,15 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
      */
     public function getUncommittedEvents()
     {
-        $stream = new DomainEventStream($this->uncommittedEvents);
+        return new DomainEventStream($this->uncommittedEvents);
+    }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function clearUncommittedEvents()
+    {
         $this->uncommittedEvents = array();
-
-        return $stream;
     }
 
     /**

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -70,7 +70,8 @@ class EventSourcingRepository implements RepositoryInterface
         Assert::isInstanceOf($aggregate, $this->aggregateClass);
 
         $domainEventStream = $aggregate->getUncommittedEvents();
-        $eventStream       = $this->decorateForWrite($aggregate, $domainEventStream);
+        $aggregate->clearUncommittedEvents();
+        $eventStream = $this->decorateForWrite($aggregate, $domainEventStream);
         $this->eventStore->append($aggregate->getId(), $eventStream);
         $this->eventBus->publish($domainEventStream);
     }

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -86,7 +86,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
 
         $expectedAggregate = $this->createAggregate();
         $expectedAggregate->apply(new DidNumberEvent(1337));
-        $expectedAggregate->getUncommittedEvents();
+        $expectedAggregate->clearUncommittedEvents();
 
         $this->assertEquals($expectedAggregate, $aggregate);
     }
@@ -136,6 +136,23 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
         $this->assertSame($event, $events[0]->getPayload());
     }
 
+
+    /**
+     * @test
+     */
+    public function it_should_clear_uncommitted_events_after_adding_an_aggregate_root()
+    {
+        $aggregate = $this->createAggregate();
+        $aggregate->apply(new DidNumberEvent(42));
+        $aggregate->apply(new DidNumberEvent(1337));
+
+        $this->assertEquals(2, count($aggregate->getUncommittedEvents()->getIterator()));
+
+        $this->repository->add($aggregate);
+
+        $this->assertEquals(0, count($aggregate->getUncommittedEvents()->getIterator()));
+    }
+
     /**
      * @return EventSourcingRepository
      */
@@ -173,6 +190,15 @@ class TestAggregate implements AggregateRoot
     }
 
     public function getUncommittedEvents()
+    {
+    }
+
+    public function hasUncommittedEvents()
+    {
+        return false;
+    }
+
+    public function clearUncommittedEvents()
     {
     }
 }


### PR DESCRIPTION
added the following methods to `AggregateRoot` and therefore to `EventSourcedAggregateRoot`:
- `hasUncommittedEvents`
- `clearUncommittedEvents`
