### PR TITLE
Symfony2 configuration conditionally loading

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
@@ -29,16 +29,16 @@ class BroadwayExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        $loader->load('services.xml');
-        $loader->load('saga.xml');
-        $loader->load('read_model.xml');
-        $loader->load('event_store.xml');
-
         $configuration = $this->getConfiguration($configs, $container);
         $config        = $this->processConfiguration($configuration, $configs);
 
-        $this->loadSagaStateRepository($config['saga'], $container);
-        $this->loadReadModelRepository($config['read_model'], $container);
+        $loader->load('services.xml');
+        $loader->load('saga.xml');        
+        $loader->load('event_store.xml');
+
+
+        $this->loadSagaStateRepository($config['saga'], $container, $loader);
+        $this->loadReadModelRepository($config['read_model'], $container, $loader);
         $this->loadCommandBus($config['command_handling'], $container);
     }
 
@@ -60,16 +60,18 @@ class BroadwayExtension extends Extension
         }
     }
 
-    private function loadSagaStateRepository(array $config, ContainerBuilder $container)
+    private function loadSagaStateRepository(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         switch ($config['repository']) {
             case 'mongodb':
+                $loader->load('saga/mongodb.xml');
                 $container->setAlias(
                     'broadway.saga.state.repository',
                     'broadway.saga.state.mongodb_repository'
                 );
                 break;
             case 'in_memory':
+                $loader->load('saga/in_memory.xml');
                 $container->setAlias(
                     'broadway.saga.state.repository',
                     'broadway.saga.state.in_memory_repository'
@@ -78,13 +80,15 @@ class BroadwayExtension extends Extension
         }
     }
 
-    private function loadReadModelRepository(array $config, ContainerBuilder $container)
+    private function loadReadModelRepository(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         switch ($config['repository']) {
             case 'elasticsearch':
+                $loader->load('read_model/elasticsearch.xml');
                 $this->configElasticsearch($config['elasticsearch'], $container);
                 break;
             case 'in_memory':
+                $loader->load('read_model/in_memory.xml');
                 $this->configInMemory($container);
                 break;
         }

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/read_model/elasticsearch.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/read_model/elasticsearch.xml
@@ -16,6 +16,5 @@
             <argument type="service" id="broadway.serializer.readmodel" />
         </service>
 
-        <service id="broadway.read_model.in_memory.repository_factory" class="Broadway\ReadModel\InMemory\InMemoryRepositoryFactory" />
     </services>
 </container>

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/read_model/in_memory.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/read_model/in_memory.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="broadway.read_model.in_memory.repository_factory" class="Broadway\ReadModel\InMemory\InMemoryRepositoryFactory" />
+    </services>
+</container>

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga.xml
@@ -10,31 +10,8 @@
             <argument type="service" id="broadway.uuid.generator" />
         </service>
 
-        <service id="broadway.saga.state.in_memory_repository" class="Broadway\Saga\State\InMemoryRepository" />
-
+        
         <service id="broadway.saga.metadata.factory" class="Broadway\Saga\Metadata\StaticallyConfiguredSagaMetadataFactory" />
-
-        <service id="broadway.saga.state.mongodb_repository" class="Broadway\Saga\State\MongoDBRepository">
-            <argument type="service" id="broadway.saga.state.mongodb_collection" />
-        </service>
-
-        <service id="broadway.saga.state.mongodb_database"
-                 class           = "Doctrine\MongoDB\Database"
-                 factory-service = "broadway.saga.state.mongodb_connection"
-                 factory-method  = "selectDatabase"
-                >
-            <argument>broadway_%kernel.environment%%storage_suffix%</argument>
-        </service>
-
-        <service id="broadway.saga.state.mongodb_connection" class="Doctrine\MongoDB\Connection" />
-
-        <service id="broadway.saga.state.mongodb_collection"
-                 class           = "Doctrine\MongoDB\Collection"
-                 factory-service = "broadway.saga.state.mongodb_database"
-                 factory-method  = "createCollection"
-                >
-            <argument>saga-state</argument>
-        </service>
 
         <service id="broadway.saga.metadata_enricher" class="Broadway\Saga\SagaMetadataEnricher" >
             <tag name="broadway.event_listener" event="broadway.saga.post_handle" method="postHandleSaga" />

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/in_memory.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/in_memory.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        
+        <service id="broadway.saga.state.in_memory_repository" class="Broadway\Saga\State\InMemoryRepository" />
+
+    </services>
+</container>

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="broadway.saga.state.mongodb_repository" class="Broadway\Saga\State\MongoDBRepository">
+            <argument type="service" id="broadway.saga.state.mongodb_collection" />
+        </service>
+
+        <service id="broadway.saga.state.mongodb_database"
+                 class           = "Doctrine\MongoDB\Database"
+                 factory-service = "broadway.saga.state.mongodb_connection"
+                 factory-method  = "selectDatabase"
+                >
+            <argument>broadway_%kernel.environment%%storage_suffix%</argument>
+        </service>
+
+        <service id="broadway.saga.state.mongodb_connection" class="Doctrine\MongoDB\Connection" />
+
+        <service id="broadway.saga.state.mongodb_collection"
+                 class           = "Doctrine\MongoDB\Collection"
+                 factory-service = "broadway.saga.state.mongodb_database"
+                 factory-method  = "createCollection"
+                >
+            <argument>saga-state</argument>
+        </service>
+
+    </services>
+</container>


### PR DESCRIPTION
My request change the configuration method for loading Symfony2 bundle.

If you configure `saga` repository to `in_memory` all `mongodb` service will not be loaded.

In same spirit, if you set the `readmodel` repository to `in_memory`, the elasticsearch service will not be loaded.

So, if you want change for use another readmodel repository, you can set `readmodel` repository to `in_memory` dans overwrite alias `broadway.read_model.repository_factory` in your configuration file.

Open to suggestions and comments.
