### PR TITLE
Make function abstract

### DIFF
--- a/src/Broadway/CommandHandling/Testing/CommandHandlerScenarioTestCase.php
+++ b/src/Broadway/CommandHandling/Testing/CommandHandlerScenarioTestCase.php
@@ -45,7 +45,5 @@ abstract class CommandHandlerScenarioTestCase extends TestCase
     /**
      * @return Broadway\CommandHandling\CommandHandler
      */
-    protected function createCommandHandler(EventStoreInterface $eventStore, EventBusInterface $eventBus)
-    {
-    }
+    abstract protected function createCommandHandler(EventStoreInterface $eventStore, EventBusInterface $eventBus);
 }


### PR DESCRIPTION
Is there any reason why this function is not abstract?
- The class is already abstract
- Testing a command handler scenario without providing a command handler seems very hard to do. 
- Also the current PhpDoc says it returns something but it's an empty function
- There is also an error in the phpdoc. (it needs at least an \ at the beginning). But I got another pull request for that one https://github.com/qandidate-labs/broadway/pull/32

I don't want to mix pull requests for different things so that's why I started a new one here. 
