### PR TITLE
CommandHandler avoid endless loop

### DIFF
--- a/src/Broadway/CommandHandling/CommandHandler.php
+++ b/src/Broadway/CommandHandling/CommandHandler.php
@@ -11,6 +11,8 @@
 
 namespace Broadway\CommandHandling;
 
+use Broadway\CommandHandling\Exception\CommandNotAnObjectException;
+
 /**
  * Convenience base class for command handlers.
  *
@@ -37,6 +39,10 @@ abstract class CommandHandler implements CommandHandlerInterface
 
     private function getHandleMethod($command)
     {
+        if (! is_object($command)) {
+            throw new CommandNotAnObjectException();
+        }
+
         $classParts = explode('\\', get_class($command));
 
         return 'handle' . end($classParts);

--- a/src/Broadway/CommandHandling/Exception/CommandNotAnObjectException.php
+++ b/src/Broadway/CommandHandling/Exception/CommandNotAnObjectException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Commands should be objects.
+ */
+class CommandNotAnObjectException extends InvalidArgumentException
+{
+}

--- a/test/Broadway/CommandHandling/CommandHandlerTest.php
+++ b/test/Broadway/CommandHandling/CommandHandlerTest.php
@@ -26,6 +26,29 @@ class CommandHandlerTest extends TestCase
 
         $this->assertTrue($commandHandler->handled);
     }
+
+    /**
+     * @test
+     *
+     * @dataProvider unresolvableCommands
+     */
+    public function handle_should_throw_exception_when_impossible_to_delegate_to_a_valid_method($command)
+    {
+        $commandHandler = new TestCommandHandler();
+        $this->setExpectedException('Broadway\CommandHandling\Exception\CommandNotAnObjectException');
+        $commandHandler->handle($command);
+    }
+
+    public function unresolvableCommands()
+    {
+        return array(
+            array(null),
+            array(false),
+            array('foo'),
+            array(1),
+            array(array('foo', 'bar'))
+        );
+    }
 }
 
 class TestCommandHandler extends CommandHandler


### PR DESCRIPTION
Background:
I was checking if commands needed to implement a certain interface. Even if it was only an empty one. This should at least force them to be objects. 
https://github.com/qandidate-labs/broadway/blob/master/src/Broadway/CommandHandling/CommandHandlerInterface.php
Turned out that wasn't the case. So I wanted to see what would happen if I send a string as a command.

I was testing this on the command line without a framework.
I expected an exception somewhere but I ended up in an endless loop.

If you check the code the get_class command did return an warning (but no exception), neither did the explode function.
This caused me to endlessly loop the method handle.
This pull request fixed that behaviour.
