### PR TITLE
CommandBusCommandAware

### DIFF
--- a/src/Broadway/CommandHandling/CommandBusCommandAwareAdapter.php
+++ b/src/Broadway/CommandHandling/CommandBusCommandAwareAdapter.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling;
+
+/**
+ * Implementation that uses the adapter pattern which lets us use a command bus which is not command aware
+ */
+class CommandBusCommandAwareAdapter implements CommandBusCommandAwareInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * Constructor.
+     *
+     * @param CommandBusInterface $commandBus A command bus which is not command aware instance.
+     */
+    public function __construct(CommandBusInterface $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function dispatch(CommandInterface $command)
+    {
+        $this->commandBus->dispatch($command);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function subscribe(CommandHandlerInterface $handler)
+    {
+        $this->commandBus->subscribe($handler);
+    }
+}

--- a/src/Broadway/CommandHandling/CommandBusCommandAwareInterface.php
+++ b/src/Broadway/CommandHandling/CommandBusCommandAwareInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling;
+
+/**
+ * A command bus which is aware that the given commands are actually commands.
+ *
+ * This means they have to implement the right interface.
+ */
+interface CommandBusCommandAwareInterface
+{
+    /**
+     * Dispatches your command object to the command handler.
+     *
+     * @param CommandInterface $command
+     */
+    public function dispatch(CommandInterface $command);
+
+    /**
+     * Subscribes the command handler to this CommandBus
+     */
+    public function subscribe(CommandHandlerInterface $handler);
+}

--- a/src/Broadway/CommandHandling/CommandInterface.php
+++ b/src/Broadway/CommandHandling/CommandInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling;
+
+/**
+ * CommandInterface
+ *
+ * When using the CommandBusCommandAware interface you need to make sure your command objects implement this interface.
+ */
+interface CommandInterface
+{
+
+}

--- a/test/Broadway/CommandHandling/CommandBusCommandAwareAdapterTest.php
+++ b/test/Broadway/CommandHandling/CommandBusCommandAwareAdapterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling;
+
+use Broadway\TestCase;
+
+/**
+ * Test file for CommandBusCommandAwareAdapter
+ */
+class CommandBusCommandAwareAdapterTest extends TestCase
+{
+    /**
+     * @var CommandBusCommandAwareAdapter
+     */
+    private $adapter;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|CommandBusInterface
+     */
+    private $adaptee;
+
+    /**
+     * @var\PHPUnit_Framework_MockObject_MockObject|CommandHandlerInterface
+     */
+    private $commandHandler;
+
+    public function setUp()
+    {
+        $this->adaptee = $this->getMock('Broadway\CommandHandling\CommandBusInterface');
+        $this->commandHandler = $this->getMock('Broadway\CommandHandling\CommandHandlerInterface');
+        $this->adapter = new CommandBusCommandAwareAdapter($this->adaptee);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_dispatch_valid_commands_to_the_actual_command_bus()
+    {
+        $command = new KissMyWifeCommand();
+        $this->adaptee->expects($this->once())->method('dispatch')
+            ->with($command);
+
+        $this->adapter->dispatch($command);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_objects_which_are_not_implementing_the_interface()
+    {
+        $command = new IAmNoTACommand();
+        $exception = false;
+        try {
+            $this->adapter->dispatch($command);
+        } catch (\Exception $e) {
+            $exception = true;
+        }
+        $this->assertTrue($exception);
+    }
+
+    /**
+     * @test
+     */
+    public function it_passes_the_subscribe_method_to_the_adaptee()
+    {
+        $this->adaptee->expects($this->once())->method('subscribe')->with($this->commandHandler);
+
+        $this->adapter->subscribe($this->commandHandler);
+    }
+}
+
+/**
+ * An invalid command
+ */
+class IAmNoTACommand {}
+
+/**
+ * A command that implements the interface
+ */
+class KissMyWifeCommand implements CommandInterface {}


### PR DESCRIPTION
:crying_cat_face: 

This pull request tries to protect you from allowing all data to pass through a commandbus. See [CommandBusInterface](https://github.com/qandidate-labs/broadway/blob/master/src/Broadway/CommandHandling/CommandBusInterface.php)

What I would expect 

```
public function dispatch(CommandInterface $command)
```

The problem is that it doesn't even force you to send objects, the argument is mixed.
So you can send
- strings (caused endless loop [link](https://github.com/qandidate-labs/broadway/pull/35))
- array of commands
- events

I understand the reason 'less coupling' but the trade off (mainly not enforcing them to be objects) can be quite nasty. But the beauty of OOP is that there are things like the Open Closed Principle. So I used the adapter pattern to workaround this. 

This is my nerdy attempt to start a discussion about this.  Sure I could just use those classes for myself (and I will if i have to)  but CommandBusCommandAwareInterface feels like a code smell
