### PR TITLE
rename getId to getAggregateRootId for aggregate roots

### DIFF
--- a/examples/event-sourced-domain-with-tests/Invites.php
+++ b/examples/event-sourced-domain-with-tests/Invites.php
@@ -32,7 +32,7 @@ class Invitation extends Broadway\EventSourcing\EventSourcedAggregateRoot
      *
      * {@inheritDoc}
      */
-    public function getId()
+    public function getAggregateRootId()
     {
         return $this->invitationId;
     }

--- a/src/Broadway/Domain/AggregateRoot.php
+++ b/src/Broadway/Domain/AggregateRoot.php
@@ -24,5 +24,5 @@ interface AggregateRoot
     /**
      * @return string
      */
-    public function getId();
+    public function getAggregateRootId();
 }

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -39,7 +39,7 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
 
         $this->playhead++;
         $this->uncommittedEvents[] = DomainMessage::recordNow(
-            $this->getId(),
+            $this->getAggregateRootId(),
             $this->playhead,
             new Metadata(array()),
             $event

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -71,14 +71,14 @@ class EventSourcingRepository implements RepositoryInterface
 
         $domainEventStream = $aggregate->getUncommittedEvents();
         $eventStream       = $this->decorateForWrite($aggregate, $domainEventStream);
-        $this->eventStore->append($aggregate->getId(), $eventStream);
+        $this->eventStore->append($aggregate->getAggregateRootId(), $eventStream);
         $this->eventBus->publish($domainEventStream);
     }
 
     private function decorateForWrite(AggregateRoot $aggregate, DomainEventStream $eventStream)
     {
         $aggregateType       = $this->getType();
-        $aggregateIdentifier = $aggregate->getId();
+        $aggregateIdentifier = $aggregate->getAggregateRootId();
 
         foreach ($this->eventStreamDecorators as $eventStreamDecorator) {
             $eventStream = $eventStreamDecorator->decorateForWrite($aggregateType, $aggregateIdentifier, $eventStream);

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -127,7 +127,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
 
         $lastCall = $this->eventStreamDecorator->getLastCall();
 
-        $this->assertEquals($aggregate->getId(), $lastCall['aggregateIdentifier']);
+        $this->assertEquals($aggregate->getAggregateRootId(), $lastCall['aggregateIdentifier']);
         $this->assertEquals('\\' . get_class($aggregate), $lastCall['aggregateType']);
 
         $events = iterator_to_array($lastCall['eventStream']);
@@ -159,7 +159,7 @@ class DidNumberEvent
 
 class AnotherTestEventSourcedAggregate extends EventSourcedAggregateRoot
 {
-    public function getId()
+    public function getAggregateRootId()
     {
         return 1337;
     }
@@ -167,7 +167,7 @@ class AnotherTestEventSourcedAggregate extends EventSourcedAggregateRoot
 
 class TestAggregate implements AggregateRoot
 {
-    public function getId()
+    public function getAggregateRootId()
     {
         return 42;
     }

--- a/test/Broadway/EventSourcing/EventSourcedAggregateRootTest.php
+++ b/test/Broadway/EventSourcing/EventSourcedAggregateRootTest.php
@@ -83,7 +83,7 @@ class MyTestAggregateRoot extends EventSourcedAggregateRoot
 {
     public $isCalled = false;
 
-    public function getId()
+    public function getAggregateRootId()
     {
         return 'y0l0';
     }

--- a/test/Broadway/EventSourcing/EventSourcedEntityTest.php
+++ b/test/Broadway/EventSourcing/EventSourcedEntityTest.php
@@ -98,7 +98,7 @@ class Aggregate extends EventSourcedAggregateRoot
         $this->handleRecursively(new Event());
     }
 
-    public function getId()
+    public function getAggregateRootId()
     {
     }
 }

--- a/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
@@ -40,7 +40,7 @@ class TestEventSourcedAggregate extends EventSourcedAggregateRoot
 {
     public $numbers;
 
-    public function getId()
+    public function getAggregateRootId()
     {
         return 42;
     }


### PR DESCRIPTION
Makes it obvious that this is used as part of the infrastructure.

Addresses #34
