### PR TITLE
further work for contracts to use interfaces instead of abstract classes

### DIFF
--- a/src/Broadway/CommandHandling/Testing/Scenario.php
+++ b/src/Broadway/CommandHandling/Testing/Scenario.php
@@ -11,7 +11,7 @@
 
 namespace Broadway\CommandHandling\Testing;
 
-use Broadway\CommandHandling\CommandHandler;
+use Broadway\CommandHandling\CommandHandlerInterface;
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
@@ -38,7 +38,7 @@ class Scenario
     public function __construct(
         PHPUnit_Framework_TestCase $testCase,
         TraceableEventStore $eventStore,
-        CommandHandler $commandHandler
+        CommandHandlerInterface $commandHandler
     ) {
         $this->testCase       = $testCase;
         $this->eventStore     = $eventStore;

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -13,6 +13,7 @@ namespace Broadway\EventSourcing;
 
 use Broadway\Domain\AggregateRoot as AggregateRootInterface;
 use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainEventStreamInterface;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 
@@ -61,7 +62,7 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
     /**
      * Initializes the aggregate using the given "history" of events.
      */
-    public function initializeState(DomainEventStream $stream)
+    public function initializeState(DomainEventStreamInterface $stream)
     {
         foreach ($stream as $message) {
             $this->playhead++;

--- a/src/Broadway/ReadModel/Projector.php
+++ b/src/Broadway/ReadModel/Projector.php
@@ -12,12 +12,11 @@
 namespace Broadway\ReadModel;
 
 use Broadway\Domain\DomainMessageInterface;
-use Broadway\EventHandling\EventListenerInterface;
 
 /**
  * Handles events and projects to a read model.
  */
-abstract class Projector implements EventListenerInterface
+abstract class Projector implements ProjectorInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Broadway/ReadModel/ProjectorInterface.php
+++ b/src/Broadway/ReadModel/ProjectorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\ReadModel;
+
+use Broadway\EventHandling\EventListenerInterface;
+
+/**
+ * Handles events and projects to a read model.
+ */
+interface ProjectorInterface extends EventListenerInterface
+{
+}

--- a/src/Broadway/ReadModel/Testing/Scenario.php
+++ b/src/Broadway/ReadModel/Testing/Scenario.php
@@ -15,7 +15,7 @@ use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\ReadModel\InMemory\InMemoryRepository;
-use Broadway\ReadModel\Projector;
+use Broadway\ReadModel\ProjectorInterface;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -38,7 +38,7 @@ class Scenario
     public function __construct(
         PHPUnit_Framework_TestCase $testCase,
         InMemoryRepository $repository,
-        Projector $projector
+        ProjectorInterface $projector
     ) {
         $this->testCase   = $testCase;
         $this->repository = $repository;


### PR DESCRIPTION
Changes include:
- a new ProjectorInterface for the Projector abstract class
- CommandHandling and ReadModel scenarios to use interfaces rather than abstract classes
- EventSourcedAggregateRoot::initializeState typehints the `DomainEventStreamInterface` instead of `DomainEventStream`

This is a follow-up to PR #2 
