### PR TITLE
Remove usage of `should` in test method names betterspecs.org/#should

### DIFF
--- a/src/Broadway/ReadModel/Testing/ReadModelTestCase.php
+++ b/src/Broadway/ReadModel/Testing/ReadModelTestCase.php
@@ -23,7 +23,7 @@ abstract class ReadModelTestCase extends TestCase
     /**
      * @test
      */
-    public function it_should_be_serializable()
+    public function its_serializable()
     {
         $this->assertInstanceOf('Broadway\Serializer\SerializableInterface', $this->createReadModel());
     }

--- a/src/Broadway/Serializer/Testing/SerializableEventTestCase.php
+++ b/src/Broadway/Serializer/Testing/SerializableEventTestCase.php
@@ -22,7 +22,7 @@ abstract class SerializableEventTestCase extends TestCase
     /**
      * @test
      */
-    public function it_should_be_serializable()
+    public function its_serializable()
     {
         $this->assertInstanceOf('Broadway\Serializer\SerializableInterface', $this->createEvent());
     }

--- a/test/Broadway/Bundle/BroadwayBundle/Command/CommandMetadataEnricherTest.php
+++ b/test/Broadway/Bundle/BroadwayBundle/Command/CommandMetadataEnricherTest.php
@@ -50,7 +50,7 @@ class CommandMetadataEnricherTest extends TestCase
     /**
      * @test
      */
-    public function it_should_add_the_command_class_and_arguments()
+    public function it_adds_the_command_class_and_arguments()
     {
         $this->enricher->handleConsoleCommandEvent($this->event);
 

--- a/test/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterBusSubscribersCompilerPassTest.php
+++ b/test/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterBusSubscribersCompilerPassTest.php
@@ -55,7 +55,7 @@ class RegisterBusSubscribersCompilerPassTest extends TestCase
     /**
      * @test
      */
-    public function command_handler_should_be_subscribed()
+    public function it_subscribes_command_handler()
     {
         $commandHandlerId = 'my_command_handler';
         $services = array(

--- a/test/Broadway/CommandHandling/CommandHandlerTest.php
+++ b/test/Broadway/CommandHandling/CommandHandlerTest.php
@@ -18,7 +18,7 @@ class CommandHandlerTest extends TestCase
     /**
      * @test
      */
-    public function handle_should_delegate_command_to_proper_handle_function()
+    public function it_delegates_command_to_proper_handle_function()
     {
         $commandHandler = new TestCommandHandler();
         $command        = new CommandHandlerTestCommand();

--- a/test/Broadway/Domain/DateTimeTest.php
+++ b/test/Broadway/Domain/DateTimeTest.php
@@ -18,7 +18,7 @@ class DateTimeTest extends TestCase
     /**
      * @test
      */
-    public function it_should_convert_back_and_forth()
+    public function it_converts_back_and_forth()
     {
         $string   = '2014-03-12T14:17:19.176169+00:00';
         $dateTime = DateTime::fromString($string);
@@ -29,7 +29,7 @@ class DateTimeTest extends TestCase
     /**
      * @test
      */
-    public function it_should_create_now()
+    public function it_creates_now()
     {
         $this->assertInstanceOf('Broadway\Domain\DateTime', DateTime::now());
     }

--- a/test/Broadway/Domain/DomainMessageTest.php
+++ b/test/Broadway/Domain/DomainMessageTest.php
@@ -18,7 +18,7 @@ class DomainMessageTest extends TestCase
     /**
      * @test
      */
-    public function its_getters_should_work()
+    public function it_has_getters()
     {
         $id       = 'Hi thur';
         $payload  = new SomeEvent();

--- a/test/Broadway/EventDispatcher/EventDispatcherTest.php
+++ b/test/Broadway/EventDispatcher/EventDispatcherTest.php
@@ -32,7 +32,7 @@ class EventDispatcherTest extends TestCase
     /**
      * @test
      */
-    public function it_should_call_the_subscribed_listeners()
+    public function it_calls_the_subscribed_listeners()
     {
         $this->dispatcher->addListener('event', array($this->listener1, 'handleEvent'));
         $this->dispatcher->addListener('event', array($this->listener2, 'handleEvent'));
@@ -46,7 +46,7 @@ class EventDispatcherTest extends TestCase
     /**
      * @test
      */
-    public function it_should_only_call_the_listener_subscribed_to_a_given_event()
+    public function it_only_calls_the_listener_subscribed_to_a_given_event()
     {
         $this->dispatcher->addListener('event1', array($this->listener1, 'handleEvent'));
         $this->dispatcher->addListener('event2', array($this->listener2, 'handleEvent'));

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -79,7 +79,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
     /**
      * @test
      */
-    public function it_should_load_an_aggregate()
+    public function it_loads_an_aggregate()
     {
         $this->eventStore->append(42, new DomainEventStream(array(
             DomainMessage::recordNow(42, 0, new Metadata(array()), new DidNumberEvent(1337))

--- a/test/Broadway/EventSourcing/EventSourcedAggregateRootTest.php
+++ b/test/Broadway/EventSourcing/EventSourcedAggregateRootTest.php
@@ -21,7 +21,7 @@ class EventSourcedAggregateRootTest extends TestCase
     /**
      * @test
      */
-    public function apply_should_use_an_incrementing_playhead()
+    public function it_applies_using_an_incrementing_playhead()
     {
         $aggregateRoot = new MyTestAggregateRoot();
         $aggregateRoot->apply(new AggregateEvent());
@@ -39,7 +39,7 @@ class EventSourcedAggregateRootTest extends TestCase
     /**
      * @test
      */
-    public function initialize_state_should_set_internal_playhead()
+    public function it_sets_internal_playhead_when_initializing()
     {
         $aggregateRoot = new MyTestAggregateRoot();
         $aggregateRoot->initializeState($this->toDomainEventStream(array(new AggregateEvent())));
@@ -55,7 +55,7 @@ class EventSourcedAggregateRootTest extends TestCase
     /**
      * @test
      */
-    public function apply_should_call_the_apply_for_specific_event()
+    public function it_calls_apply_for_specific_events()
     {
         $aggregateRoot = new MyTestAggregateRoot();
         $aggregateRoot->initializeState($this->toDomainEventStream(array(new AggregateEvent())));

--- a/test/Broadway/EventSourcing/EventSourcedEntityTest.php
+++ b/test/Broadway/EventSourcing/EventSourcedEntityTest.php
@@ -18,7 +18,7 @@ class EventSourcedEntityTest extends TestCase
     /**
      * @test
      */
-    public function it_should_handle_events_recursively()
+    public function it_handles_events_recursively()
     {
         $aggregateRoot = new Aggregate();
         $child         = new Entity();
@@ -38,7 +38,7 @@ class EventSourcedEntityTest extends TestCase
     /**
      * @test
      */
-    public function it_should_apply_event_to_aggregate_root()
+    public function it_applies_events_to_aggregate_root()
     {
         $aggregateRoot = $this->getMock('Broadway\EventSourcing\Aggregate', array('apply'));
         $aggregateRoot->expects($this->once())

--- a/test/Broadway/EventStore/EventStoreTest.php
+++ b/test/Broadway/EventStore/EventStoreTest.php
@@ -26,7 +26,7 @@ abstract class EventStoreTest extends TestCase
      * @test
      * @dataProvider idDataProvider
      */
-    public function it_should_create_a_new_entry_when_id_is_new($id)
+    public function it_creates_a_new_entry_when_id_is_new($id)
     {
         $domainEventStream = new DomainEventStream(array(
             $this->createDomainMessage($id, 0),
@@ -44,7 +44,7 @@ abstract class EventStoreTest extends TestCase
      * @test
      * @dataProvider idDataProvider
      */
-    public function it_should_append_to_an_already_existing_stream($id)
+    public function it_appends_to_an_already_existing_stream($id)
     {
         $dateTime = DateTime::fromString('2014-03-12T14:17:19.176169+00:00');
         $domainEventStream = new DomainEventStream(array(
@@ -78,7 +78,7 @@ abstract class EventStoreTest extends TestCase
      * @dataProvider idDataProvider
      * @expectedException Broadway\EventStore\EventStreamNotFoundException
      */
-    public function it_should_throw_an_exception_when_requesting_the_stream_of_a_non_existing_aggregate($id)
+    public function it_throws_an_exception_when_requesting_the_stream_of_a_non_existing_aggregate($id)
     {
         $this->eventStore->load($id);
     }
@@ -88,7 +88,7 @@ abstract class EventStoreTest extends TestCase
      * @dataProvider idDataProvider
      * @expectedException Broadway\EventStore\EventStoreException
      */
-    public function it_should_throw_an_exception_when_appending_a_duplicate_playhead($id)
+    public function it_throws_an_exception_when_appending_a_duplicate_playhead($id)
     {
         $domainMessage     = $this->createDomainMessage($id, 0);
         $baseStream        = new DomainEventStream(array($domainMessage));
@@ -103,7 +103,7 @@ abstract class EventStoreTest extends TestCase
      * @expectedException PHPUnit_Framework_Error
      * @expectedExceptionMessage Object of class Broadway\EventStore\IdentityThatCannotBeConvertedToAString could not be converted to string
      */
-    public function it_should_throw_an_exception_when_an_id_cannot_be_converted_to_a_string()
+    public function it_throws_an_exception_when_an_id_cannot_be_converted_to_a_string()
     {
         $id = new IdentityThatCannotBeConvertedToAString(
             'Yolntbyaac' //You only live nine times because you are a cat

--- a/test/Broadway/Saga/SagaMetadataEnricherTest.php
+++ b/test/Broadway/Saga/SagaMetadataEnricherTest.php
@@ -28,7 +28,7 @@ class SagaMetadataEnricherTest extends TestCase
     /**
      * @test
      */
-    public function it_should_store_the_state()
+    public function it_stores_the_state()
     {
         $type = 'type';
         $id   = 'id';
@@ -43,7 +43,7 @@ class SagaMetadataEnricherTest extends TestCase
     /**
      * @test
      */
-    public function it_should_use_the_last_saga_data_it_received()
+    public function it_uses_the_latest_saga_data_it_received()
     {
         $this->sagaMetadataEnricher->postHandleSaga('type1', 'id1');
         $this->sagaMetadataEnricher->postHandleSaga('type2', 'id2');
@@ -57,7 +57,7 @@ class SagaMetadataEnricherTest extends TestCase
     /**
      * @test
      */
-    public function it_should_enrich_multiple_instances_of_metadata()
+    public function it_enriches_multiple_instances_of_metadata()
     {
         $this->sagaMetadataEnricher->postHandleSaga('type', 'id');
 


### PR DESCRIPTION
It seems like the test uses a lot of `should` instead of just stating what it does, and what the purpose of the test is.

betterspecs.org/#should is properly the best description to why should is disallowed. Also its a best practice to not use should when speccing .
