### PR TITLE
RegisterBusSubscribersCompilerPass: Add support for parameter return values

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterBusSubscribersCompilerPass.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterBusSubscribersCompilerPass.php
@@ -52,8 +52,8 @@ class RegisterBusSubscribersCompilerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds($this->serviceTag) as $id => $attributes) {
             $def = $container->getDefinition($id);
-            // We must assume that the class value has been correctly filled, even if the service is created by a factory
-            $class = $def->getClass();
+            // Definition getClass can return a parameter
+            $class = $container->getParameterBag()->resolveValue($def->getClass());
 
             $refClass = new ReflectionClass($class);
 


### PR DESCRIPTION
When using a parameter for my projector classes I received this exception:

```
ReflectionException: Class %my_parameter% does not exist
```

This PR solves this by asking for the parameter first before doing the reflection.

Edit: When looking if this was a known symfony bug http://stackoverflow.com/questions/19266204/after-tagging-a-service-in-services-yml-symfony-starts-throwing-reflectionexcept

Edit2: https://github.com/richsage/RMSPushNotificationsBundle/blob/master/DependencyInjection/Compiler/AddHandlerPass.php
