### PR TITLE
Create a Postgres-specific implementation of DBALEventStore

### DIFF
--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -28,15 +28,15 @@ use Doctrine\DBAL\Schema\Schema;
  */
 class DBALEventStore implements EventStoreInterface
 {
-    private $connection;
+    protected $connection;
 
-    private $payloadSerializer;
+    protected $payloadSerializer;
 
-    private $metadataSerializer;
+    protected $metadataSerializer;
 
-    private $loadStatement = null;
+    protected $loadStatement = null;
 
-    private $tableName;
+    protected $tableName;
 
     /**
      * @param string $tableName
@@ -101,7 +101,7 @@ class DBALEventStore implements EventStoreInterface
         }
     }
 
-    private function insertMessage(Connection $connection, DomainMessage $domainMessage)
+    protected function insertMessage(Connection $connection, DomainMessage $domainMessage)
     {
         $data = array(
             'uuid'       => $domainMessage->getId(),
@@ -116,7 +116,7 @@ class DBALEventStore implements EventStoreInterface
     }
 
     /**
-     * @return Doctrine\DBAL\Schema\Table|null
+     * @return \Doctrine\DBAL\Schema\Table|null
      */
     public function configureSchema(Schema $schema)
     {
@@ -147,7 +147,7 @@ class DBALEventStore implements EventStoreInterface
         return $table;
     }
 
-    private function prepareLoadStatement()
+    protected function prepareLoadStatement()
     {
         if (null === $this->loadStatement) {
             $query = 'SELECT uuid, playhead, metadata, payload, recordedOn
@@ -160,7 +160,7 @@ class DBALEventStore implements EventStoreInterface
         return $this->loadStatement;
     }
 
-    private function deserializeEvent($row)
+    protected function deserializeEvent($row)
     {
         return new DomainMessage(
             $row['uuid'],

--- a/src/Broadway/EventStore/PostgresDBALEventStore.php
+++ b/src/Broadway/EventStore/PostgresDBALEventStore.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore;
+
+use Broadway\Domain\DomainMessage;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Event store using a PostgreSQL database as storage.
+ *
+ * The implementation uses doctrine DBAL for the communication with the
+ * underlying data store, and has the SQL definitions tailored specifically to
+ * deal with PostgreSQL's default of forcing lowercase for all column names.
+ */
+class PostgresDBALEventStore extends DBALEventStore
+{
+    public function configureTable()
+    {
+        $schema = new Schema();
+
+        $table = $schema->createTable($this->tableName);
+
+        $table->addColumn("\"id\"", 'integer', array('autoincrement' => true));
+        $table->addColumn("\"uuid\"", 'guid', array('length' => 36));
+        $table->addColumn("\"playhead\"", 'integer', array('unsigned' => true));
+        $table->addColumn("\"payload\"", 'text');
+        $table->addColumn("\"metadata\"", 'text');
+        $table->addColumn("\"recordedOn\"", 'string', array('length' => 32));
+        $table->addColumn("\"type\"", 'text');
+
+        $table->setPrimaryKey(array('id'));
+        $table->addUniqueIndex(array('uuid', 'playhead'));
+
+        return $table;
+    }
+
+    protected function insertMessage(Connection $connection, DomainMessage $domainMessage)
+    {
+        $data = array(
+            '"uuid"'       => $domainMessage->getId(),
+            '"playhead"'   => $domainMessage->getPlayhead(),
+            '"metadata"'   => json_encode($this->metadataSerializer->serialize($domainMessage->getMetadata())),
+            '"payload"'    => json_encode($this->payloadSerializer->serialize($domainMessage->getPayload())),
+            '"recordedOn"' => $domainMessage->getRecordedOn()->toString(),
+            '"type"'       => $domainMessage->getType(),
+        );
+
+        $connection->insert($this->tableName, $data);
+    }
+
+    protected function prepareLoadStatement()
+    {
+        if (null === $this->loadStatement) {
+            $query = 'SELECT "uuid", "playhead", "metadata", "payload", "recordedOn"
+                FROM ' . $this->tableName . '
+                WHERE "uuid" = :uuid
+                ORDER BY "playhead" ASC';
+            $this->loadStatement = $this->connection->prepare($query);
+        }
+
+        return $this->loadStatement;
+    }
+}


### PR DESCRIPTION
Due to PostgreSQL's default of setting lowercase on column names, the
standard implementation of DBALEventStore would not work with
Postgres (See Issue #52).

Fixing the quoting to work with PosgreSQL would then break the class
such that it would no longer work wit MySQL. Thus, a new version was
needed that would work with Postgres, allowing the original to
continue working as it was.

This commit changes a few properties and methods of DBALEventStore
from private to protected, and adds a PostgresDBALEventStore class
which extends DBALEventStore and overrides the methods where the
column quoting is needed. No other implementation changes were made
to the class.
