### PR TITLE
CmdHandler getHandleMethod from private to protected

### DIFF
--- a/src/Broadway/CommandHandling/CommandHandler.php
+++ b/src/Broadway/CommandHandling/CommandHandler.php
@@ -35,7 +35,7 @@ abstract class CommandHandler implements CommandHandlerInterface
         $this->$method($command);
     }
 
-    private function getHandleMethod($command)
+    protected function getHandleMethod($command)
     {
         $classParts = explode('\\', get_class($command));
 


### PR DESCRIPTION
My use case: 
- I want to make it much more obvious that there is no handler method available for the given command ('typo', 'not yet implemented'). 

This code is not possible:

``` php
abstract class MilioCommandHandler extends CommandHandler
{
    /**
     * {@inheritDoc}
     */
    public function handle($command)
    {
        $method = $this->getHandleMethod($command);  //this is impossible because the method is private
        if (!method_exists($this, $method)) {
            throw new \Exception(sprintf('Command %s has no handle method', get_class($command)));
        }
        $this->$method($command);
    }
}
```

Sure I could just copy paste this code... But why not make it protected? :crown: 
- It's a good candidate for users who want to change the method name
- It makes it possible to overwrite the handle function and still rely on the getHandleMethod (as in my use case)
