### PR TITLE
Remove Uuid component from readme + fix SagaScenarioTestCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ component for more information.
 - [Repository](src/Broadway/Repository/)
 - [Saga](src/Broadway/Saga/)
 - [Serializer](src/Broadway/Serializer/)
-- [Uuid](src/Broadway/Uuid/)
 
 ## Integrations
 

--- a/src/Broadway/Saga/Testing/SagaScenarioTestCase.php
+++ b/src/Broadway/Saga/Testing/SagaScenarioTestCase.php
@@ -13,11 +13,11 @@ namespace Broadway\Saga\Testing;
 
 use Broadway\CommandHandling\Testing\TraceableCommandBus;
 use Broadway\EventDispatcher\EventDispatcher;
-use Broadway\Uuid\UuidGeneratorInterface;
 use Broadway\Saga\Metadata\StaticallyConfiguredSagaMetadataFactory;
 use Broadway\Saga\MultipleSagaManager;
 use Broadway\Saga\State\InMemoryRepository;
 use Broadway\Saga\State\StateManager;
+use Broadway\UuidGenerator\UuidGeneratorInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 
 class SagaScenarioTestCase extends TestCase


### PR DESCRIPTION
We moved the Uuid component to https://github.com/qandidate-labs/broadway-uuid-generator

The readme contains outdated information and the SagaScenariaTestCase wasn't updated to reflect this change.
