### PR TITLE
[WIP] [RFC] EventStore management

### DIFF
--- a/src/Broadway/EventStore/CallableEventVisitor.php
+++ b/src/Broadway/EventStore/CallableEventVisitor.php
@@ -1,0 +1,31 @@
+<?php 
+
+namespace Broadway\EventStore;
+
+use Broadway\Domain\DomainMessageInterface;
+use InvalidArgumentException;
+
+class CallableEventVisitor implements EventVisitorInterface
+{
+    private $callable;
+
+    /**
+     * @param callable $callable
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($callable)
+    {
+        if (!is_callable($callable)) {
+            throw new InvalidArgumentException("First argument to new CallableEventVisitor must be callable");
+        }
+        $this->callable = $callable;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function doWithEvent(DomainMessageInterface $domainMessage)
+    {
+        call_user_func($this->callable, $domainMessage);
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/BinaryOperator.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/BinaryOperator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+final class BinaryOperator extends DBALCriteria
+{
+    private $criteria1;
+    private $criteria2;
+    private $operator;
+
+    public function __construct(DBALCriteria $criteria1, $operator, DBALCriteria $criteria2)
+    {
+        $this->criteria1 = $criteria1;
+        $this->operator = $operator;
+        $this->criteria2 = $criteria2;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function parse($entryKey, &$whereClause, ParameterRegistry $parameters)
+    {
+        $whereClause .= '(';
+        $this->criteria1->parse($entryKey, $whereClause, $parameters);
+        $whereClause .= ') '.$this->operator.' (';
+        $this->criteria2->parse($entryKey, $whereClause, $parameters);
+        $whereClause .= ')';
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/CollectionOperator.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/CollectionOperator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+final class CollectionOperator extends DBALCriteria
+{
+    private $propertyName;
+    private $expression;
+    private $operator;
+
+    public function __construct(DBALProperty $property, $operator, $expression)
+    {
+        $this->propertyName = $property;
+        $this->operator = $operator;
+        $this->expression = $expression;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function parse($entryKey, &$whereClause, ParameterRegistry $parameters)
+    {
+        $this->propertyName->parse($entryKey, $whereClause);
+        $whereClause .= ' '.$this->operator.' ';
+        if ($this->expression instanceof DBALProperty) {
+            $this->expression->parse($entryKey, $whereClause);
+        } else {
+            $whereClause .= '('.$parameters->register($this->expression).')';
+        }
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/DBALCriteria.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/DBALCriteria.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+use Broadway\EventStore\Management\CriteriaInterface;
+
+abstract class DBALCriteria implements CriteriaInterface
+{
+    /**
+     * Returns a criteria instance where both <code>this</code> and given <code>criteria</code> must match.
+     *
+     * @param CriteriaInterface $criteria The criteria that must match
+     * @return CriteriaInterface a criteria instance that matches if both <code>this</code> and <code>criteria</code> match
+     */
+    public function andWith(CriteriaInterface $criteria)
+    {
+        return new BinaryOperator($this, "AND", $criteria);
+    }
+
+    /**
+     * Returns a criteria instance where either <code>this</code> or the given <code>criteria</code> must match.
+     *
+     * @param CriteriaInterface $criteria criteria that must match if <code>this</code> doesn't match
+     * @return CriteriaInterface a criteria instance that matches if <code>this</code> or the given <code>criteria</code> match
+     */
+    public function orWith(CriteriaInterface $criteria)
+    {
+        return new BinaryOperator($this, "OR", $criteria);
+    }
+
+    /**
+     * Parses the criteria to a SQL compatible where clause and parameter values.
+     *
+     * @param string $entryKey The variable assigned to the entry in the whereClause
+     * @param string $whereClause The buffer to write the where clause to.
+     * @param ParameterRegistry $parameters The registry where parameters and assigned values can be registered.
+     * @return void
+     */
+    abstract public function parse($entryKey, &$whereClause, ParameterRegistry $parameters);
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/DBALCriteriaBuilder.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/DBALCriteriaBuilder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+use Broadway\EventStore\Management\CriteriaBuilderInterface;
+
+class DBALCriteriaBuilder implements CriteriaBuilderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function property($propertyName)
+    {
+        return new DBALProperty($propertyName);
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/DBALProperty.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/DBALProperty.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+use Broadway\EventStore\Management\expression;
+use Broadway\EventStore\Management\PropertyInterface;
+
+class DBALProperty implements PropertyInterface
+{
+    /** @var string */
+    private $propertyName;
+
+    public function __construct($propertyName)
+    {
+        $this->propertyName = $propertyName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function lessThan($expression)
+    {
+        return new SimpleOperator($this, "<", $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function lessThanEquals($expression)
+    {
+        return new SimpleOperator($this, "<=", $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function greaterThan($expression)
+    {
+        return new SimpleOperator($this, ">", $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function greaterThanEquals($expression)
+    {
+        return new SimpleOperator($this, ">=", $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function is($expression)
+    {
+        return new Equals($this, $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isNot($expression)
+    {
+        return new NotEquals($this, $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function in($expression)
+    {
+        return new CollectionOperator($this, 'IN', $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function notIn($expression)
+    {
+        return new CollectionOperator($this, 'NOT IN', $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beginsWith($expression)
+    {
+        $expression = $this->escapeLikeExpression($expression);
+        return new SimpleOperator($this, 'LIKE', "$expression%");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function endsWith($expression)
+    {
+        $expression = $this->escapeLikeExpression($expression);
+        return new SimpleOperator($this, 'LIKE', "%$expression");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function contains($expression)
+    {
+        $expression = $this->escapeLikeExpression($expression);
+        return new SimpleOperator($this, 'LIKE', "%$expression%");
+    }
+
+    /*
+     * Escape a LIKE expression
+     * @todo is this good enough
+     */
+    private function escapeLikeExpression($expression)
+    {
+        return addcslashes($expression, '_%');
+    }
+
+
+    /**
+     * Parse the property value to a valid EJQL expression.
+     *
+     * @param string $entryKey The variable assigned to the entry holding the property
+     * @param string $stringBuilder The builder to append the expression to
+     */
+    public function parse($entryKey, &$stringBuilder)
+    {
+        if ($entryKey != null && strlen($entryKey) > 0) {
+            $stringBuilder .= $entryKey . '.';
+        }
+        $stringBuilder .= $this->propertyName;
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/Equals.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/Equals.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+final class Equals extends DBALCriteria
+{
+    private $propertyName;
+    private $expression;
+
+    public function __construct(DBALProperty $property, $expression)
+    {
+        $this->propertyName = $property;
+        $this->expression = $expression;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function parse($entryKey, &$whereClause, ParameterRegistry $parameters)
+    {
+        $this->propertyName->parse($entryKey, $whereClause);
+        if (is_null($this->expression)) {
+            $whereClause .= ' IS NULL';
+        } else {
+            $whereClause .= ' = ';
+            if ($this->expression instanceof DBALProperty) {
+                $this->expression->parse($entryKey, $whereClause);
+            } else {
+                $whereClause .= $parameters->register($this->expression);
+            }
+        }
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/NotEquals.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/NotEquals.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+final class NotEquals extends DBALCriteria
+{
+    private $propertyName;
+    private $expression;
+
+    public function __construct(DBALProperty $property, $expression)
+    {
+        $this->propertyName = $property;
+        $this->expression = $expression;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function parse($entryKey, &$whereClause, ParameterRegistry $parameters)
+    {
+        $this->propertyName->parse($entryKey, $whereClause);
+        if (is_null($this->expression)) {
+            $whereClause .= ' IS NOT NULL';
+        } else {
+            $whereClause .= ' <> ';
+            if ($this->expression instanceof DBALProperty) {
+                $this->expression->parse($entryKey, $whereClause);
+            } else {
+                $whereClause .= $parameters->register($this->expression);
+            }
+        }
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/ParameterRegistry.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/ParameterRegistry.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+
+class ParameterRegistry
+{
+    private $parameters = array();
+
+    /**
+     * @param mixed $expression
+     * @return string
+     */
+    public function register($expression)
+    {
+        $this->parameters[] = $expression;
+        return '?';
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Broadway/EventStore/DBAL/Criteria/SimpleOperator.php
+++ b/src/Broadway/EventStore/DBAL/Criteria/SimpleOperator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Broadway\EventStore\DBAL\Criteria;
+
+final class SimpleOperator extends DBALCriteria
+{
+    private $propertyName;
+    private $operator;
+    private $expression;
+
+    public function __construct(DBALProperty $property, $operator, $expression)
+    {
+        $this->propertyName = $property;
+        $this->operator = $operator;
+        $this->expression = $expression;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function parse($entryKey, &$whereClause, ParameterRegistry $parameters)
+    {
+        $this->propertyName->parse($entryKey, $whereClause);
+        $whereClause .= ' '.$this->operator.' ';
+
+        if ($this->expression instanceof DBALProperty) {
+            $this->expression->parse($entryKey, $whereClause);
+        } else {
+            $whereClause .= $parameters->register($this->expression);
+        }
+    }
+}

--- a/src/Broadway/EventStore/EventVisitorInterface.php
+++ b/src/Broadway/EventStore/EventVisitorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Broadway\EventStore;
+
+use Broadway\Domain\DomainMessageInterface;
+
+interface EventVisitorInterface
+{
+    /**
+     * Called for each event loaded from the event store.
+     *
+     * @param DomainMessageInterface $domainMessage to be loaded
+     * @return void
+     */
+    public function doWithEvent(DomainMessageInterface $domainMessage);
+}

--- a/src/Broadway/EventStore/Management/CriteriaBuilderInterface.php
+++ b/src/Broadway/EventStore/Management/CriteriaBuilderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Broadway\EventStore\Management;
+
+
+interface CriteriaBuilderInterface
+{
+    /**
+     * Returns a property instance that can be used to build criteria. The given <code>propertyName</code> must hold a
+     * valid value for the Event Store that returns that value. Typically, it requires "indexed" values to be used,
+     * such as event identifier, aggregate identifier, timestamp, etc.
+     *
+     * @param string $propertyName
+     * @return PropertyInterface
+     */
+    public function property($propertyName);
+}

--- a/src/Broadway/EventStore/Management/CriteriaInterface.php
+++ b/src/Broadway/EventStore/Management/CriteriaInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Broadway\EventStore\Management;
+
+interface CriteriaInterface
+{
+    /**
+     * Returns a criteria instance where both <code>this</code> and given <code>criteria</code> must match.
+     *
+     * @param CriteriaInterface $criteria The criteria that must match
+     * @return CriteriaInterface a criteria instance that matches if both <code>this</code> and <code>criteria</code> match
+     */
+    public function andWith(CriteriaInterface $criteria);
+
+    /**
+     * Returns a criteria instance where either <code>this</code> or the given <code>criteria</code> must match.
+     *
+     * @param CriteriaInterface $criteria criteria that must match if <code>this</code> doesn't match
+     * @return CriteriaInterface a criteria instance that matches if <code>this</code> or the given <code>criteria</code> match
+     */
+    public function orWith(CriteriaInterface $criteria);
+}

--- a/src/Broadway/EventStore/Management/EventStoreManagementInterface.php
+++ b/src/Broadway/EventStore/Management/EventStoreManagementInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Broadway\EventStore\Management;
+
+use Broadway\EventStore\EventVisitorInterface;
+
+interface EventStoreManagementInterface
+{
+    /**
+     * Loads all events available in the event store that match the given <code>criteria</code> and calls {@link
+     * EventVisitor#doWithEvent(org.axonframework.domain.DomainEventMessage)} for each event found. Events of a single
+     * aggregate are guaranteed to be ordered by their sequence number.
+     * <p/>
+     * Implementations are encouraged, though not required, to supply events in the absolute chronological order.
+     * <p/>
+     * Processing stops when the visitor throws an exception.
+     *
+     * @param EventVisitorInterface $visitor receives each loaded event
+     * @param CriteriaInterface $criteria criteria describing the events to select
+     * @return void
+     */
+    public function visitEvents(EventVisitorInterface $visitor, CriteriaInterface $criteria = null);
+
+    /**
+     * Returns a CriteriaBuilder that allows the construction of criteria for this EventStore implementation.
+     *
+     * @return CriteriaBuilderInterface a builder to create Criteria for this Event Store.
+     */
+    public function newCriteriaBuilder();
+}

--- a/src/Broadway/EventStore/Management/PropertyInterface.php
+++ b/src/Broadway/EventStore/Management/PropertyInterface.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Broadway\EventStore\Management;
+
+interface PropertyInterface
+{
+    /**
+     * Returns a criteria instance where the property must be "less than" the given <code>expression</code>. Some event
+     * stores also allow the given expression to be a property.
+     *
+     * @param mixed expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "less than" requirement.
+     */
+    public function lessThan($expression);
+
+    /**
+     * Returns a criteria instance where the property must be "less than" or "equal to" the given
+     * <code>expression</code>. Some event stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "less than or equals" requirement.
+     */
+    public function lessThanEquals($expression);
+
+    /**
+     * Returns a criteria instance where the property must be "greater than" the given <code>expression</code>. Some
+     * event stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "greater than" requirement.
+     */
+    public function greaterThan($expression);
+
+    /**
+     * Returns a criteria instance where the property must be "greater than" or "equal to" the given
+     * <code>expression</code>. Some event stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "greater than or equals" requirement.
+     */
+    public function greaterThanEquals($expression);
+
+    /**
+     * Returns a criteria instance where the property must "equal" the given <code>expression</code>. Some event stores
+     * also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing an "equals" requirement.
+     */
+    public function is($expression);
+
+    /**
+     * Returns a criteria instance where the property must be "not equal to" the given <code>expression</code>. Some
+     * event stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "not equals" requirement.
+     */
+    public function isNot($expression);
+
+    /**
+     * Returns a criteria instance where the property must be "in" the given <code>expression</code>. Some event stores
+     * also allow the given expression to be a property.
+     * <p/>
+     * Note that the given <code>expression</code> must describe a collection of some sort.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "is in" requirement.
+     */
+    public function in($expression);
+
+    /**
+     * Returns a criteria instance where the property must be "not in" the given <code>expression</code>. Some event
+     * stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "is not in" requirement.
+     */
+    public function notIn($expression);
+
+    /**
+     * Returns a criteria instance where the property must begin with the given <code>expression</code>. Some event
+     * stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "begins with" requirement.
+     */
+    public function beginsWith($expression);
+
+    /**
+     * Returns a criteria instance where the property must end with the given <code>expression</code>. Some event
+     * stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "ends with" requirement.
+     */
+    public function endsWith($expression);
+
+    /**
+     * Returns a criteria instance where the property must contain the given <code>expression</code>. Some event
+     * stores also allow the given expression to be a property.
+     *
+     * @param mixed $expression The expression to match against the property
+     * @return CriteriaInterface a criteria instance describing a "contains" requirement.
+     */
+    public function contains($expression);
+}


### PR DESCRIPTION
Allows events to be pulled out of the EventStore using a fluid criteria builder.

- includes a CallableEventVisitor, so event's can be easily processed using a callback function.
- no tests as of yet
- beyond the Axon implementation, added ability to query a property using `beginsWith`, `contains` and `endsWith`. In DBAL implementation, this correlates with `LIKE` statements.

Example of usage:

```php
<?php
$visitor = new CallableEventVisitor(function (DomainMessage $domainMessage) { /* do something */ });
$criteriaBuilder = $eventStore->newCriteriaBuilder();
$type = $criteriaBuilder->property('type'); // corresponds to column in events table
$criteria = $type->beginsWith('MyBoundedContext.AggregateRoot1.')->orWith(
    $type->beginsWith('MyBoundedContext.AggregateRoot2.')
);
$eventStore->visitEvents($visitor, $criteria);
```

*Heavily* based on AxonFramework's implementation.

*PS: having issues installing `instaclick/base-test-bundle` dependency at the moment, so no idea if this will interfere with tests passing, but at this point it's about getting feedback.*