### PR TITLE
Perform some cleanup using php-cs-fixer

### DIFF
--- a/examples/event-dispatcher/event-dispatcher.php
+++ b/examples/event-dispatcher/event-dispatcher.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../bootstrap.php';
 $eventDispatcher = new Broadway\EventDispatcher\EventDispatcher();
 
 // You can register any callable
-$eventDispatcher->addListener('my_event', function($arg1, $arg2) {
+$eventDispatcher->addListener('my_event', function ($arg1, $arg2) {
     echo "Arg1: $arg1\n";
     echo "Arg2: $arg2\n";
 });

--- a/examples/event-handling/event-handling.php
+++ b/examples/event-handling/event-handling.php
@@ -18,7 +18,7 @@ $eventBus->subscribe($eventListener);
 
 // Create a domain event stream to publish
 $metadata          = new Broadway\Domain\Metadata(array('source' => 'example'));
-$domainMessage     = Broadway\Domain\DomainMessage::recordNow(42, 1, $metadata, new stdClass);
+$domainMessage     = Broadway\Domain\DomainMessage::recordNow(42, 1, $metadata, new stdClass());
 $domainEventStream = new Broadway\Domain\DomainEventStream(array($domainMessage));
 
 // Publish the message, and get output from the event handler \o/

--- a/examples/event-sourced-domain-with-tests/Invites.php
+++ b/examples/event-sourced-domain-with-tests/Invites.php
@@ -166,7 +166,6 @@ class AcceptedEvent extends InvitationEvent { }
 class DeclineCommand extends InvitationCommand { }
 class DeclinedEvent extends InvitationEvent { }
 
-
 /*
  * A command handler will be registered with the command bus and handle the
  * commands that are dispatched. The command handler can be seen as a small

--- a/src/Broadway/EventSourcing/AggregateFactory/AggregateFactoryInterface.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/AggregateFactoryInterface.php
@@ -10,7 +10,7 @@ use Broadway\Domain\DomainEventStreamInterface;
 interface AggregateFactoryInterface
 {
     /**
-     * @param string $aggregateClass the FQCN of the Aggregate to create
+     * @param string                     $aggregateClass    the FQCN of the Aggregate to create
      * @param DomainEventStreamInterface $domainEventStream
      *
      * @return \Broadway\EventSourcing\EventSourcedAggregateRoot

--- a/src/Broadway/EventSourcing/AggregateFactory/NamedConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/NamedConstructorAggregateFactory.php
@@ -4,7 +4,6 @@ namespace Broadway\EventSourcing\AggregateFactory;
 
 use Assert\Assertion as Assert;
 use Broadway\Domain\DomainEventStreamInterface;
-use Broadway\EventSourcing\EventSourcedAggregateRoot;
 
 /**
  * Creates aggregates by passing a DomainEventStream to the given public static method

--- a/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
@@ -16,7 +16,7 @@ class PublicConstructorAggregateFactory implements AggregateFactoryInterface
      */
     public function create($aggregateClass, DomainEventStreamInterface $domainEventStream)
     {
-        $aggregate = new $aggregateClass;
+        $aggregate = new $aggregateClass();
         $aggregate->initializeState($domainEventStream);
 
         return $aggregate;

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -63,6 +63,7 @@ class EventSourcingRepository implements RepositoryInterface
     {
         try {
             $domainEventStream = $this->eventStore->load($id);
+
             return $this->aggregateFactory->create($this->aggregateClass, $domainEventStream);
         } catch (EventStreamNotFoundException $e) {
             throw AggregateNotFoundException::create($id, $e);

--- a/test/Broadway/Auditing/CommandSerializerTest.php
+++ b/test/Broadway/Auditing/CommandSerializerTest.php
@@ -45,7 +45,7 @@ class CommandSerializerTest extends TestCase
 
 class MyCommand
 {
-    public    $public    = 'public';
+    public $public    = 'public';
     protected $protected = 'protected';
-    private   $private   = 'private';
+    private $private   = 'private';
 }

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -18,7 +18,6 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventHandling\SimpleEventBus;
 use Broadway\EventHandling\TraceableEventBus;
-use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
 use Broadway\EventStore\EventStoreInterface;
 use Broadway\EventStore\InMemoryEventStore;
 use Broadway\EventStore\TraceableEventStore;

--- a/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
@@ -48,7 +48,7 @@ class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
         // make sure events exist in the event store
         $id = 'y0l0';
         $this->eventStore->append($id, new DomainEventStream(array(
-            DomainMessage::recordNow(42, 0, new Metadata(array()), new DidEvent)
+            DomainMessage::recordNow(42, 0, new Metadata(array()), new DidEvent())
         )));
 
         $repository = $this->repositoryWithStaticAggregateFactory();
@@ -71,7 +71,7 @@ class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
         // make sure events exist in the event store
         $id = 'y0l0';
         $this->eventStore->append($id, new DomainEventStream(array(
-            DomainMessage::recordNow(42, 0, new Metadata(array()), new DidEvent)
+            DomainMessage::recordNow(42, 0, new Metadata(array()), new DidEvent())
         )));
 
         $repository = $this->repositoryWithStaticAggregateFactory('someUnknownStaticmethod');
@@ -110,7 +110,6 @@ class TestEventSourcedAggregate extends EventSourcedAggregateRoot
         $this->numbers[] = $event->number;
     }
 }
-
 
 class TestEventSourcedAggregateWithStaticConstructor extends EventSourcedAggregateRoot
 {

--- a/test/Broadway/Saga/Metadata/MetadataTest.php
+++ b/test/Broadway/Saga/Metadata/MetadataTest.php
@@ -11,7 +11,6 @@
 
 namespace Broadway\Saga\Metadata;
 
-use Broadway\Saga\State;
 use Broadway\TestCase;
 
 class StaticallyConfiguredSagaMetadataTest extends TestCase
@@ -21,7 +20,7 @@ class StaticallyConfiguredSagaMetadataTest extends TestCase
     public function setUp()
     {
         $this->metadata = new Metadata(array(
-            'StaticallyConfiguredSagaMetadataTestSagaTestEvent1' => function() { return 'criteria'; },
+            'StaticallyConfiguredSagaMetadataTestSagaTestEvent1' => function () { return 'criteria'; },
         ));
     }
 

--- a/test/Broadway/Saga/Metadata/StaticallyConfiguredSagaMetadataFactoryTest.php
+++ b/test/Broadway/Saga/Metadata/StaticallyConfiguredSagaMetadataFactoryTest.php
@@ -28,7 +28,7 @@ class StaticallyConfiguredSagaMetadataFactoryTest extends TestCase
         $saga = $this->getMockBuilder('Broadway\Saga\Metadata\StaticallyConfiguredSagaInterface')->getMock();
         $saga->staticExpects($this->any())
             ->method('configuration')
-            ->will($this->returnValue(array('StaticallyConfiguredSagaMetadataFactoryTestEvent' => function($event) use ($criteria) { return $criteria;})));
+            ->will($this->returnValue(array('StaticallyConfiguredSagaMetadataFactoryTestEvent' => function ($event) use ($criteria) { return $criteria;})));
 
         $metadata = $metadataFactory->create($saga);
 

--- a/test/Broadway/Saga/MultipleSagaManagerTest.php
+++ b/test/Broadway/Saga/MultipleSagaManagerTest.php
@@ -260,9 +260,9 @@ class SagaManagerTestSaga implements StaticallyConfiguredSagaInterface
     public static function configuration()
     {
         return array(
-            'TestEvent1'    => function() { return new Criteria(array('appId' => 42)); },
-            'TestEvent2'    => function() { },
-            'TestEventDone' => function() { return new Criteria(array('appId' => 42)); },
+            'TestEvent1'    => function () { return new Criteria(array('appId' => 42)); },
+            'TestEvent2'    => function () { },
+            'TestEventDone' => function () { return new Criteria(array('appId' => 42)); },
         );
     }
 }

--- a/test/Broadway/Saga/State/CriteriaTest.php
+++ b/test/Broadway/Saga/State/CriteriaTest.php
@@ -14,7 +14,7 @@ namespace Broadway\Saga;
 use Broadway\Saga\State\Criteria;
 use Broadway\TestCase;
 
-class SagaStateCriteriaTest extends TestCase
+class CriteriaTest extends TestCase
 {
     /**
      * @test

--- a/test/Broadway/Saga/State/MongoDBRepositoryTest.php
+++ b/test/Broadway/Saga/State/MongoDBRepositoryTest.php
@@ -25,7 +25,7 @@ class MongoDBRepositoryTest extends AbstractRepositoryTest
     protected function createRepository()
     {
         $config = new Configuration();
-        $config->setLoggerCallable(function($msg) {});
+        $config->setLoggerCallable(function ($msg) {});
         $this->connection = new Connection(null, array(), $config);
         $db   = $this->connection->selectDatabase(self::$dbName);
         $coll = $db->createCollection('test');


### PR DESCRIPTION
$ php-cs-fixer --verbose fix examples/
   1) event-dispatcher/event-dispatcher.php (function_declaration)
   2) event-handling/event-handling.php (new_with_braces)
   3) event-sourced-domain-with-tests/Invites.php (extra_empty_lines)

$ php-cs-fixer --verbose fix src/
   1) Broadway/EventSourcing/AggregateFactory/AggregateFactoryInterface.php (phpdoc_params)
   2) Broadway/EventSourcing/AggregateFactory/NamedConstructorAggregateFactory.php (unused_use)
   3) Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php (new_with_braces)
   4) Broadway/EventSourcing/EventSourcingRepository.php (return)

$ php-cs-fixer --verbose fix test/
   1) Broadway/Auditing/CommandSerializerTest.php (visibility)
   2) Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php (unused_use)
   3) Broadway/EventSourcing/EventSourcingRepositoryTest.php (extra_empty_lines, new_with_braces)
   4) Broadway/Saga/Metadata/MetadataTest.php (unused_use, function_declaration)
   5) Broadway/Saga/Metadata/StaticallyConfiguredSagaMetadataFactoryTest.php (function_declaration)
   6) Broadway/Saga/MultipleSagaManagerTest.php (function_declaration)
   7) Broadway/Saga/State/CriteriaTest.php (psr0)
   8) Broadway/Saga/State/MongoDBRepositoryTest.php (function_declaration)
