### PR TITLE
Make the simple command bus more resilient.

### DIFF
--- a/src/Broadway/CommandHandling/SimpleCommandBus.php
+++ b/src/Broadway/CommandHandling/SimpleCommandBus.php
@@ -38,13 +38,18 @@ class SimpleCommandBus implements CommandBusInterface
         if (! $this->isDispatching) {
             $this->isDispatching = true;
 
-            while ($command = array_shift($this->queue)) {
-                foreach ($this->commandHandlers as $handler) {
-                    $handler->handle($command);
+            try {
+                while ($command = array_shift($this->queue)) {
+                    foreach ($this->commandHandlers as $handler) {
+                        $handler->handle($command);
+                    }
                 }
-            }
 
-            $this->isDispatching = false;
+                $this->isDispatching = false;
+            } catch (\Exception $e) {
+                $this->isDispatching = false;
+                throw $e;
+            }
         }
     }
 }


### PR DESCRIPTION
If an exception occurs during the handling of a command, the simple
command bus becomes unusable (`$isDispatching` stays `true`).
With this change the bus will be able to dispatch subsequent commands
even if an exception occurs.