### PR TITLE
Fix docblock typo

### DIFF
--- a/src/Broadway/ReadModel/ElasticSearch/ElasticSearchRepository.php
+++ b/src/Broadway/ReadModel/ElasticSearch/ElasticSearchRepository.php
@@ -48,7 +48,7 @@ class ElasticSearchRepository implements RepositoryInterface
     }
 
     /**
-     * {@inhericDoc}
+     * {@inheritDoc}
      */
     public function save(ReadModelInterface $data)
     {
@@ -66,7 +66,7 @@ class ElasticSearchRepository implements RepositoryInterface
     }
 
     /**
-     * {@inhericDoc}
+     * {@inheritDoc}
      */
     public function find($id)
     {
@@ -86,7 +86,7 @@ class ElasticSearchRepository implements RepositoryInterface
     }
 
     /**
-     * {@inhericDoc}
+     * {@inheritDoc}
      */
     public function findBy(array $fields)
     {

--- a/src/Broadway/ReadModel/InMemory/InMemoryRepository.php
+++ b/src/Broadway/ReadModel/InMemory/InMemoryRepository.php
@@ -25,7 +25,7 @@ class InMemoryRepository implements RepositoryInterface, TransferableInterface
     private $data = array();
 
     /**
-     * {@inhericDoc}
+     * {@inheritDoc}
      */
     public function save(ReadModelInterface $model)
     {
@@ -33,7 +33,7 @@ class InMemoryRepository implements RepositoryInterface, TransferableInterface
     }
 
     /**
-     * {@inhericDoc}
+     * {@inheritDoc}
      */
     public function find($id)
     {
@@ -89,7 +89,7 @@ class InMemoryRepository implements RepositoryInterface, TransferableInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function remove($id)
     {


### PR DESCRIPTION
Fix a few instances of {@inheritDoc} that were misspelled as {@inhericDoc}
