### PR TITLE
Aggregate Root Test Scenario

### DIFF
--- a/examples/event-sourced-domain-with-tests/README.md
+++ b/examples/event-sourced-domain-with-tests/README.md
@@ -2,11 +2,12 @@ Event sourced domain with tests
 ===============================
 
 A small example of an implementation of a small domain model. The example
-consists of two files. The first file `Invites` contains the implementation of
+consists of three files. The first file `Invites` contains the implementation of
 the domain model. The second file `InvitesTest` contains a PHPUnit test suite
-to test the domain.
+to only test the Invites model. The third file `InvitationCommandHandlerTest` contains
+a PHPunit test suite to test the available commands.
 
-The two files contain comments about what is happening.
+The files contain comments about what is happening.
 
 The PHPUnit tests can be run by changing to the directory of the tests and running:
 
@@ -14,9 +15,9 @@ The PHPUnit tests can be run by changing to the directory of the tests and runni
 $ phpunit .
 PHPUnit 4.1.0 by Sebastian Bergmann.
 
-.......
+..............
 
-Time: 70 ms, Memory: 4.00Mb
+Time: 52 ms, Memory: 4.50Mb
 
-OK (7 tests, 9 assertions)
+OK (14 tests, 19 assertions)
 ```

--- a/src/Broadway/EventSourcing/Testing/AggregateRootScenarioTestCase.php
+++ b/src/Broadway/EventSourcing/Testing/AggregateRootScenarioTestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventSourcing\Testing;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
+
+/**
+ * Base test case that can be used to set up a command handler scenario.
+ */
+abstract class AggregateRootScenarioTestCase extends TestCase
+{
+    /**
+     * @var Scenario
+     */
+    protected $scenario;
+
+    public function setUp()
+    {
+        $this->scenario = $this->createScenario();
+    }
+
+    /**
+     * @return Scenario
+     */
+    protected function createScenario()
+    {
+        $aggregateRootClass = $this->getAggregateRootClass();
+        $factory            = $this->getAggregateRootFactory();
+
+        return new Scenario($this, $factory, $aggregateRootClass);
+    }
+
+    /**
+     * Returns a string representing the aggregate root
+     *
+     * @return string AggregateRoot
+     */
+    abstract protected function getAggregateRootClass();
+
+    /**
+     * Returns a factory for instantiating an aggregate
+     *
+     * @return Broadway\EventSourcing\AggregateFactory\AggregateFactoryInterface $factory
+     */
+    protected function getAggregateRootFactory()
+    {
+        return new PublicConstructorAggregateFactory();
+    }
+}

--- a/src/Broadway/EventSourcing/Testing/Scenario.php
+++ b/src/Broadway/EventSourcing/Testing/Scenario.php
@@ -13,30 +13,50 @@ namespace Broadway\EventSourcing\Testing;
 
 use PHPUnit_Framework_TestCase;
 
+use Broadway\EventSourcing\AggregateFactory\AggregateFactoryInterface;
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+
 /**
  * Helper testing scenario to test command event sourced aggregate roots.
  *
  * The scenario will help with testing event sourced aggregate roots. A
  * scenario consists of three steps:
  *
- * 1) given(): Load a history of events in the event store
+ * 1) given(): Initialize the aggregate root using a history of events
  * 2) when():  A callable that calls a method on the event sourced aggregate root
  * 3) then():  Events that should have been applied
  */
 class Scenario
 {
     private $testCase;
-    private $aggregateRoot;
+    private $factory;
+
+    private $aggregateRootClass;
     private $aggregateRootInstance;
+    private $aggregateId;
 
     /**
      * @param PHPUnit_Framework_TestCase $testcase
-     * @param string                     $aggregateRoot
+     * @param string                     $aggregateRootClass
      */
-    public function __construct(PHPUnit_Framework_TestCase $testCase, $aggregateRoot)
+    public function __construct(PHPUnit_Framework_TestCase $testCase, AggregateFactoryInterface $factory, $aggregateRootClass)
     {
-        $this->testCase      = $testCase;
-        $this->aggregateRoot = $aggregateRoot;
+        $this->testCase           = $testCase;
+        $this->factory            = $factory;
+        $this->aggregateRootClass = $aggregateRootClass;
+        $this->aggregateId        = 1;
+    }
+
+    /**
+     * @param string $aggregateId
+     */
+    public function withAggregateId($aggregateId)
+    {
+        $this->aggregateId = $aggregateId;
+
+        return $this;
     }
 
     /**
@@ -50,8 +70,18 @@ class Scenario
             return $this;
         }
 
-        $this->aggregateRootInstance = new $this->aggregateRoot();
-        $this->aggregateRootInstance->initializeState($givens);
+        $messages = array();
+        $playhead = -1;
+        foreach ($givens as $event) {
+            $playhead++;
+            $messages[] = DomainMessage::recordNow(
+                $this->aggregateId, $playhead, new Metadata(array()), $event
+            );
+        }
+
+        $this->aggregateRootInstance = $this->factory->create(
+            $this->aggregateRootClass, new DomainEventStream($messages)
+        );
 
         return $this;
     }
@@ -70,7 +100,7 @@ class Scenario
         if ($this->aggregateRootInstance === null) {
             $this->aggregateRootInstance = $when($this->aggregateRootInstance);
 
-            $this->testCase->assertInstanceOf($this->aggregateRoot, $this->aggregateRootInstance);
+            $this->testCase->assertInstanceOf($this->aggregateRootClass, $this->aggregateRootInstance);
         } else {
             $when($this->aggregateRootInstance);
         }
@@ -85,8 +115,24 @@ class Scenario
      */
     public function then(array $thens)
     {
-        $this->testCase->assertEquals($thens, $this->aggregateRootInstance->getUncommittedEvents());
+        $this->testCase->assertEquals($thens, $this->getEvents());
 
         return $this;
     }
+
+    /**
+     * @return array Payloads of the recorded events
+     */
+    private function getEvents()
+    {
+        $recordedEvents = $this->aggregateRootInstance->getUncommittedEvents();
+        $events = array();
+
+        foreach ($recordedEvents as $message) {
+            $events[] = $message->getPayload();
+        }
+
+        return $events;
+    }
+
 }


### PR DESCRIPTION
The current `EventSourcing/Testing/Scenario` seems to have fallen behind. This pull request added some functionality such that you can easily test your `EventSourcedAggregateRoot` objects without using a command bus.

Nb: I also added an example which was basically copied from the `event-sourced-domain-with-test` but changed such that it uses the new `AggregateRootScenarioTestCase` class.
It might be better to use a different example and also add a testcase for `EventSourcedEntity`.