### PR TITLE
Extract reusable ElasticSearch client handling from the implementation

### DIFF
--- a/src/Broadway/ReadModel/ElasticSearch/ElasticSearchRepository.php
+++ b/src/Broadway/ReadModel/ElasticSearch/ElasticSearchRepository.php
@@ -22,29 +22,11 @@ use Elasticsearch\Common\Exceptions\Missing404Exception;
  */
 class ElasticSearchRepository implements RepositoryInterface
 {
-    private $client;
-    private $serializer;
-    private $index;
-    private $class;
-    private $notAnalyzedFields;
+    private $objectRepository;
 
-    /**
-     * @param string $index
-     * @param string $class
-     * @param array  $notAnalyzedFields = array
-     */
-    public function __construct(
-        Client $client,
-        SerializerInterface $serializer,
-        $index,
-        $class,
-        array $notAnalyzedFields = array()
-    ) {
-        $this->client            = $client;
-        $this->serializer        = $serializer;
-        $this->index             = $index;
-        $this->class             = $class;
-        $this->notAnalyzedFields = $notAnalyzedFields;
+    public function __construct(ElsaticSearchSerializableObjectRepository $objectRepository)
+    {
+        $this->objectRepository = $objectRepository;
     }
 
     /**
@@ -52,17 +34,7 @@ class ElasticSearchRepository implements RepositoryInterface
      */
     public function save(ReadModelInterface $data)
     {
-        $serializedReadModel = $this->serializer->serialize($data);
-
-        $params = array(
-            'index'   => $this->index,
-            'type'    => $serializedReadModel['class'],
-            'id'      => $data->getId(),
-            'body'    => $serializedReadModel['payload'],
-            'refresh' => true,
-        );
-
-        $this->client->index($params);
+        $this->objectRepository->save($data);
     }
 
     /**
@@ -70,19 +42,7 @@ class ElasticSearchRepository implements RepositoryInterface
      */
     public function find($id)
     {
-        $params = array(
-            'index' => $this->index,
-            'type'  => $this->class,
-            'id'    => $id,
-        );
-
-        try {
-            $result = $this->client->get($params);
-        } catch (Missing404Exception $e) {
-            return null;
-        }
-
-        return $this->deserializeHit($result);
+        return $this->objectRepository->find($id);
     }
 
     /**
@@ -94,7 +54,7 @@ class ElasticSearchRepository implements RepositoryInterface
             return array();
         }
 
-        return $this->query($this->buildFindByQuery($fields));
+        return $this->objectRepository->query($this->buildFindByQuery($fields));
     }
 
     /**
@@ -102,7 +62,7 @@ class ElasticSearchRepository implements RepositoryInterface
      */
     public function findAll()
     {
-        return $this->query($this->buildFindAllQuery());
+        return $this->objectRepository->query($this->buildFindAllQuery());
     }
 
     /**
@@ -110,66 +70,7 @@ class ElasticSearchRepository implements RepositoryInterface
      */
     public function remove($id)
     {
-        try {
-            $this->client->delete(array(
-                'id'      => $id,
-                'index'   => $this->index,
-                'type'    => $this->class,
-                'refresh' => true,
-            ));
-        } catch (Missing404Exception $e) { // It was already deleted or never existed, fine by us!
-        }
-    }
-
-    private function searchAndDeserializeHits(array $query)
-    {
-        try {
-            $result = $this->client->search($query);
-        } catch (Missing404Exception $e) {
-            return array();
-        }
-
-        if (! array_key_exists('hits', $result)) {
-            return array();
-        }
-
-        return $this->deserializeHits($result['hits']['hits']);
-    }
-
-    /**
-     * @param array   $query
-     * @param array   $facets
-     * @param integer $size
-     *
-     * @return array
-     */
-    protected function search(array $query, array $facets = array(), $size = 500)
-    {
-        try {
-            return $this->client->search(array(
-                'index' => $this->index,
-                'body'  => array(
-                    'query'  => $query,
-                    'facets' => $facets,
-                ),
-                'size' => $size,
-            ));
-        } catch (Missing404Exception $e) {
-            return array();
-        }
-    }
-
-    protected function query(array $query)
-    {
-        return $this->searchAndDeserializeHits(
-            array(
-                'index' => $this->index,
-                'body'  => array(
-                    'query' => $query,
-                ),
-                'size'  => 500,
-            )
-        );
+        $this->objectRepository->remove($id);
     }
 
     private function buildFindByQuery(array $fields)
@@ -191,21 +92,6 @@ class ElasticSearchRepository implements RepositoryInterface
         );
     }
 
-    private function deserializeHit(array $hit)
-    {
-        return $this->serializer->deserialize(
-            array(
-                'class'   => $hit['_type'],
-                'payload' => $hit['_source'],
-            )
-        );
-    }
-
-    private function deserializeHits(array $hits)
-    {
-        return array_map(array($this, 'deserializeHit'), $hits);
-    }
-
     private function buildFilter(array $filter)
     {
         $retval = array();
@@ -215,78 +101,5 @@ class ElasticSearchRepository implements RepositoryInterface
         }
 
         return array('and' => $retval);
-    }
-
-    /**
-     * Creates the index for this repository's ReadModel.
-     *
-     * @return boolean True, if the index was successfully created
-     */
-    public function createIndex()
-    {
-        $class = $this->class;
-
-        $indexParams = array(
-            'index' => $this->index,
-        );
-
-        if (count($this->notAnalyzedFields)) {
-            $indexParams['body'] = array(
-                'mappings' => array(
-                    $class => array(
-                        '_source'    => array(
-                            'enabled' => true
-                        ),
-                        'properties' => $this->createNotAnalyzedFieldsMapping($this->notAnalyzedFields),
-                    )
-                )
-            );
-        }
-
-        $this->client->indices()->create($indexParams);
-        $response = $this->client->cluster()->health(array(
-            'index'           => $this->index,
-            'wait_for_status' => 'yellow',
-            'timeout'         => '5s',
-        ));
-
-        return isset($response['status']) && $response['status'] !== 'red';
-    }
-
-    /**
-     * Deletes the index for this repository's ReadModel.
-     *
-     * @return True, if the index was successfully deleted
-     */
-    public function deleteIndex()
-    {
-        $indexParams = array(
-            'index'   => $this->index,
-            'timeout' => '5s',
-        );
-
-        $this->client->indices()->delete($indexParams);
-
-        $response = $this->client->cluster()->health(array(
-            'index'           => $this->index,
-            'wait_for_status' => 'yellow',
-            'timeout'         => '5s',
-        ));
-
-        return isset($response['status']) && $response['status'] !== 'red';
-    }
-
-    private function createNotAnalyzedFieldsMapping(array $notAnalyzedFields)
-    {
-        $fields = array();
-
-        foreach ($notAnalyzedFields as $field) {
-            $fields[$field] = array(
-                'type'  => 'string',
-                'index' => 'not_analyzed'
-            );
-        }
-
-        return $fields;
     }
 }

--- a/src/Broadway/ReadModel/ElasticSearch/ElasticSearchRepositoryFactory.php
+++ b/src/Broadway/ReadModel/ElasticSearch/ElasticSearchRepositoryFactory.php
@@ -34,6 +34,8 @@ class ElasticSearchRepositoryFactory implements RepositoryFactoryInterface
      */
     public function create($name, $class, array $notAnalyzedFields = array())
     {
-        return new ElasticSearchRepository($this->client, $this->serializer, $name, $class, $notAnalyzedFields);
+        $objectRepository = new ElsaticSearchSerializableObjectRepository($this->client, $this->serializer, $name, $class, $notAnalyzedFields);
+
+        return new ElasticSearchRepository($objectRepository);
     }
 }

--- a/src/Broadway/ReadModel/ElasticSearch/ElsaticSearchSerializableObjectRepository.php
+++ b/src/Broadway/ReadModel/ElasticSearch/ElsaticSearchSerializableObjectRepository.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Broadway\ReadModel\ElasticSearch;
+
+use Broadway\ReadModel\ReadModelInterface;
+use Broadway\Serializer\SerializerInterface;
+use Elasticsearch\Client;
+use Elasticsearch\Common\Exceptions\Missing404Exception;
+
+class ElsaticSearchSerializableObjectRepository
+{
+    private $client;
+    private $serializer;
+    private $index;
+    private $class;
+    private $notAnalyzedFields;
+
+    /**
+     * @param string $index
+     * @param string $class
+     * @param array  $notAnalyzedFields = array
+     */
+    public function __construct(
+        Client $client,
+        SerializerInterface $serializer,
+        $index,
+        $class,
+        array $notAnalyzedFields = array()
+    ) {
+        $this->client            = $client;
+        $this->serializer        = $serializer;
+        $this->index             = $index;
+        $this->class             = $class;
+        $this->notAnalyzedFields = $notAnalyzedFields;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function save(ReadModelInterface $data)
+    {
+        $serializedReadModel = $this->serializer->serialize($data);
+
+        $params = array(
+            'index'   => $this->index,
+            'type'    => $serializedReadModel['class'],
+            'id'      => $data->getId(),
+            'body'    => $serializedReadModel['payload'],
+            'refresh' => true,
+        );
+
+        $this->client->index($params);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function find($id)
+    {
+        $params = array(
+            'index' => $this->index,
+            'type'  => $this->class,
+            'id'    => $id,
+        );
+
+        try {
+            $result = $this->client->get($params);
+        } catch (Missing404Exception $e) {
+            return null;
+        }
+
+        return $this->deserializeHit($result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function remove($id)
+    {
+        try {
+            $this->client->delete(array(
+                'id'      => $id,
+                'index'   => $this->index,
+                'type'    => $this->class,
+                'refresh' => true,
+            ));
+        } catch (Missing404Exception $e) { // It was already deleted or never existed, fine by us!
+        }
+    }
+
+    /**
+     * @param array $query
+     *
+     * @return array
+     */
+    public function searchAndDeserializeHits(array $query)
+    {
+        try {
+            $result = $this->client->search($query);
+        } catch (Missing404Exception $e) {
+            return array();
+        }
+
+        if (! array_key_exists('hits', $result)) {
+            return array();
+        }
+
+        return $this->deserializeHits($result['hits']['hits']);
+    }
+
+    /**
+     * @param array   $query
+     * @param array   $facets
+     * @param integer $size
+     *
+     * @return array
+     */
+    public function search(array $query, array $facets = array(), $size = 500)
+    {
+        try {
+            return $this->client->search(array(
+                'index' => $this->index,
+                'body'  => array(
+                    'query'  => $query,
+                    'facets' => $facets,
+                ),
+                'size' => $size,
+            ));
+        } catch (Missing404Exception $e) {
+            return array();
+        }
+    }
+
+    /**
+     * @param array $query
+     *
+     * @return array
+     */
+    public function query(array $query, $size = 500)
+    {
+        return $this->searchAndDeserializeHits(
+            array(
+                'index' => $this->index,
+                'body'  => array(
+                    'query' => $query,
+                ),
+                'size'  => $size,
+            )
+        );
+    }
+
+    private function deserializeHit(array $hit)
+    {
+        return $this->serializer->deserialize(
+            array(
+                'class'   => $hit['_type'],
+                'payload' => $hit['_source'],
+            )
+        );
+    }
+
+    private function deserializeHits(array $hits)
+    {
+        return array_map(array($this, 'deserializeHit'), $hits);
+    }
+
+    /**
+     * Creates the index for this repository's ReadModel.
+     *
+     * @return boolean True, if the index was successfully created
+     */
+    public function createIndex()
+    {
+        $class = $this->class;
+
+        $indexParams = array(
+            'index' => $this->index,
+        );
+
+        if (count($this->notAnalyzedFields)) {
+            $indexParams['body'] = array(
+                'mappings' => array(
+                    $class => array(
+                        '_source'    => array(
+                            'enabled' => true
+                        ),
+                        'properties' => $this->createNotAnalyzedFieldsMapping($this->notAnalyzedFields),
+                    )
+                )
+            );
+        }
+
+        $this->client->indices()->create($indexParams);
+        $response = $this->client->cluster()->health(array(
+            'index'           => $this->index,
+            'wait_for_status' => 'yellow',
+            'timeout'         => '5s',
+        ));
+
+        return isset($response['status']) && $response['status'] !== 'red';
+    }
+
+    /**
+     * Deletes the index for this repository's ReadModel.
+     *
+     * @return True, if the index was successfully deleted
+     */
+    public function deleteIndex()
+    {
+        $indexParams = array(
+            'index'   => $this->index,
+            'timeout' => '5s',
+        );
+
+        $this->client->indices()->delete($indexParams);
+
+        $response = $this->client->cluster()->health(array(
+            'index'           => $this->index,
+            'wait_for_status' => 'yellow',
+            'timeout'         => '5s',
+        ));
+
+        return isset($response['status']) && $response['status'] !== 'red';
+    }
+
+    /**
+     * @param array $notAnalyzedFields
+     * @return array
+     */
+    public function createNotAnalyzedFieldsMapping(array $notAnalyzedFields)
+    {
+        $fields = array();
+
+        foreach ($notAnalyzedFields as $field) {
+            $fields[$field] = array(
+                'type'  => 'string',
+                'index' => 'not_analyzed'
+            );
+        }
+
+        return $fields;
+    }
+} 

--- a/test/Broadway/ReadModel/ElasticSearch/ElasticSearchRepositoryFactoryTest.php
+++ b/test/Broadway/ReadModel/ElasticSearch/ElasticSearchRepositoryFactoryTest.php
@@ -25,7 +25,9 @@ class ElasticSearchRepositoryFactoryTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $repository = new ElasticSearchRepository($client, $serializer, 'test', 'Class');
+        $objectRepository = new ElsaticSearchSerializableObjectRepository($client, $serializer, 'test', 'Class');
+
+        $repository = new ElasticSearchRepository($objectRepository);
         $factory    = new ElasticSearchRepositoryFactory($client, $serializer);
 
         $this->assertEquals($repository, $factory->create('test', 'Class'));
@@ -41,7 +43,9 @@ class ElasticSearchRepositoryFactoryTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $repository = new ElasticSearchRepository($client, $serializer, 'test', 'Class', array('id'));
+        $objectRepository = new ElsaticSearchSerializableObjectRepository($client, $serializer, 'test', 'Class', array('id'));
+
+        $repository = new ElasticSearchRepository($objectRepository);
         $factory    = new ElasticSearchRepositoryFactory($client, $serializer);
 
         $this->assertEquals($repository, $factory->create('test', 'Class', array('id')));


### PR DESCRIPTION
This could prove to be useful in the case that someone wants to leverage existing ElasticSearch code without extending the base ElasticSearch repository implementations. In particular, this is useful if someone does not have a need or desire to extend the base class but still wants to use some of its tools without having to copy & paste a LOT of code.

The name could possibly use some work. It might also want to live elsewhere. It is currently as tested as it was before, but only by way of being used in the same way. It might make sense to also extract the tests so that they are testing the newly extracted class rather than only testing it *through* the ElasticSearch repository implementation.

It might also make sense to create a factory to create instances of these. :)

refs #109