### PR TITLE
Create a method to retrieve the unique set of stream ids from the event store

### DIFF
--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -101,6 +101,22 @@ class DBALEventStore implements EventStoreInterface
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function getStreamIds()
+    {
+        $statement = $this->connection->prepare('SELECT DISTINCT uuid FROM ' . $this->tableName);
+        $statement->execute();
+
+        return array_map(
+            function($row) {
+                return $row['uuid'];
+            },
+            $statement->fetchAll()
+        );
+    }
+
     private function insertMessage(Connection $connection, DomainMessage $domainMessage)
     {
         $data = array(

--- a/src/Broadway/EventStore/EventStoreInterface.php
+++ b/src/Broadway/EventStore/EventStoreInterface.php
@@ -30,4 +30,11 @@ interface EventStoreInterface
      * @param DomainEventStreamInterface $eventStream
      */
     public function append($id, DomainEventStreamInterface $eventStream);
+
+    /**
+     * The stream ids in the event store
+     *
+     * @return array
+     */
+    public function getStreamIds();
 }

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -56,6 +56,14 @@ class InMemoryEventStore implements EventStoreInterface
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function getStreamIds()
+    {
+        return array_keys($this->events);
+    }
+
     private function assertPlayhead($events, $playhead)
     {
         if (isset($events[$playhead])) {

--- a/src/Broadway/EventStore/TraceableEventStore.php
+++ b/src/Broadway/EventStore/TraceableEventStore.php
@@ -65,6 +65,14 @@ class TraceableEventStore implements EventStoreInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getStreamIds()
+    {
+        return $this->eventStore->getStreamIds();
+    }
+
+    /**
      * Start tracing.
      */
     public function trace()

--- a/test/Broadway/EventStore/EventStoreTest.php
+++ b/test/Broadway/EventStore/EventStoreTest.php
@@ -20,6 +20,7 @@ use Broadway\TestCase;
 
 abstract class EventStoreTest extends TestCase
 {
+    /** @var EventStoreInterface */
     protected $eventStore;
 
     /**
@@ -71,6 +72,38 @@ abstract class EventStoreTest extends TestCase
             $this->createDomainMessage($id, 5, $dateTime),
         ));
         $this->assertEquals($expected, $this->eventStore->load($id));
+    }
+
+    /**
+     * @test
+     */
+    public function it_gets_the_stream_ids_from_the_event_store()
+    {
+        $dateTime = DateTime::fromString('2014-03-12T14:17:19.176169+00:00');
+
+        $ids = array(
+            'aabb1653-e2e5-45d6-8979-087ed2b9f38f',
+            '90cdeb53-af8a-4474-ac5e-ae202c1e962b',
+            '5fdcfec7-063e-4433-91ba-32d120d7e03b',
+        );
+
+        foreach ($ids as $id) {
+            $domainEventStream = new DomainEventStream(array(
+                $this->createDomainMessage($id, 0, $dateTime),
+                $this->createDomainMessage($id, 1, $dateTime),
+                $this->createDomainMessage($id, 2, $dateTime),
+            ));
+
+            $this->eventStore->append($id, $domainEventStream);
+        }
+
+        $streamIds = $this->eventStore->getStreamIds();
+
+        $this->assertCount(count($ids), $streamIds);
+
+        foreach ($ids as $expectedId) {
+            $this->assertContains($expectedId, $streamIds);
+        }
     }
 
     /**


### PR DESCRIPTION
I created a helper method in the event store implementations to provide back the unique set of stream ids in the event store.

My use case for this is that I'm building a symfony command for rebuilding projections and I needed to be able to retrieve the stream id's so that I could then rebuild each event stream

```php
foreach ($eventStore->getStreamIds() as $id) {
    $eventStore->load($id);
    $eventBus->publish(...);
    // etc
}
```