### PR TITLE
Publish decorated event stream

### DIFF
--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -80,7 +80,7 @@ class EventSourcingRepository implements RepositoryInterface
         $domainEventStream = $aggregate->getUncommittedEvents();
         $eventStream       = $this->decorateForWrite($aggregate, $domainEventStream);
         $this->eventStore->append($aggregate->getAggregateRootId(), $eventStream);
-        $this->eventBus->publish($domainEventStream);
+        $this->eventBus->publish($eventStream);
     }
 
     private function decorateForWrite(AggregateRoot $aggregate, DomainEventStream $eventStream)

--- a/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
@@ -33,7 +33,7 @@ class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
 
     /**
      * @test
-     * @expectedException Assert\InvalidArgumentException
+     * @expectedException \Assert\InvalidArgumentException
      */
     public function it_throws_an_exception_when_instantiated_with_a_class_that_is_not_an_EventSourcedAggregateRoot()
     {


### PR DESCRIPTION
Small change to have EventSourcingRepository publish the decorated event stream instead of the undecorated one.

The current implementation (non-decorated) doesn't allow for access to any metadata from the projectors on the initial publish. The metadata is available in the projectors on subsequent publishes (e.g., if the read model is rebuilt).

The decorated stream is already available in the repository at the time of publishing, however it was only being used in the ```append()``` operation and not the ```publish()``` that followed (the pre-decoration array of events was instead published).  So this adds no additional overhead; it merely makes more information available (information that is being saved to the database, and is available on subsequent publishes)

Original discussion of this missing functionality began [here](https://github.com/qandidate-labs/broadway/issues/61#issuecomment-57801381), and further research [here](https://github.com/qandidate-labs/broadway/issues/61#issuecomment-58119917) indicates that metadata should be available for use with projections