### PR TITLE
Extracted interfaces from `DomainMessage`

### DIFF
--- a/src/Broadway/Domain/AbstractMessage.php
+++ b/src/Broadway/Domain/AbstractMessage.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\Domain;
+
+/**
+ * Represents an important change in the domain.
+ */
+abstract class AbstractMessage implements DomainMessageInterface, RecorderInterface
+{
+    /**
+     * @var int
+     */
+    private $playhead;
+
+    /**
+     * @var Metadata
+     */
+    private $metadata;
+
+    /**
+     * @var mixed
+     */
+    private $payload;
+
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var DateTime
+     */
+    private $recordedOn;
+
+    /**
+     * Should return the class name of the message instance to use
+     *
+     * @return string
+     */
+    protected static function getMessageClass()
+    {
+        return get_called_class();
+    }
+
+    /**
+     * @param string   $id
+     * @param int      $playhead
+     * @param Metadata $metadata
+     * @param mixed    $payload
+     * @param DateTime $recordedOn
+     */
+    public function __construct($id, $playhead, Metadata $metadata, $payload, DateTime $recordedOn)
+    {
+        $this->id         = $id;
+        $this->playhead   = $playhead;
+        $this->metadata   = $metadata;
+        $this->payload    = $payload;
+        $this->recordedOn = $recordedOn;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPlayhead()
+    {
+        return $this->playhead;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPayload()
+    {
+        return $this->payload;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRecordedOn()
+    {
+        return $this->recordedOn;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getType()
+    {
+        return strtr(get_class($this->payload), '\\', '.');
+    }
+
+    /**
+     * @param string   $id
+     * @param int      $playhead
+     * @param Metadata $metadata
+     * @param mixed    $payload
+     *
+     * @return DomainMessage
+     */
+    public static function recordNow($id, $playhead, Metadata $metadata, $payload)
+    {
+        $class = static::getMessageClass();
+
+        return new $class($id, $playhead, $metadata, $payload, DateTime::now());
+    }
+}

--- a/src/Broadway/Domain/DomainMessage.php
+++ b/src/Broadway/Domain/DomainMessage.php
@@ -14,110 +14,8 @@ namespace Broadway\Domain;
 /**
  * Represents an important change in the domain.
  */
-class DomainMessage implements DomainMessageInterface
+class DomainMessage extends AbstractMessage implements EnrichableDomainMessageInterface
 {
-    /**
-     * @var int
-     */
-    private $playhead;
-
-    /**
-     * @var Metadata
-     */
-    private $metadata;
-
-    /**
-     * @var mixed
-     */
-    private $payload;
-
-    /**
-     * @var string
-     */
-    private $id;
-
-    /**
-     * @var DateTime
-     */
-    private $recordedOn;
-
-    /**
-     * @param string   $id
-     * @param int      $playhead
-     * @param Metadata $metadata
-     * @param mixed    $payload
-     * @param DateTime $recordedOn
-     */
-    public function __construct($id, $playhead, Metadata $metadata, $payload, DateTime $recordedOn)
-    {
-        $this->id         = $id;
-        $this->playhead   = $playhead;
-        $this->metadata   = $metadata;
-        $this->payload    = $payload;
-        $this->recordedOn = $recordedOn;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getPlayhead()
-    {
-        return $this->playhead;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getMetadata()
-    {
-        return $this->metadata;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getPayload()
-    {
-        return $this->payload;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getRecordedOn()
-    {
-        return $this->recordedOn;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getType()
-    {
-        return strtr(get_class($this->payload), '\\', '.');
-    }
-
-    /**
-     * @param string   $id
-     * @param int      $playhead
-     * @param Metadata $metadata
-     * @param mixed    $payload
-     *
-     * @return DomainMessage
-     */
-    public static function recordNow($id, $playhead, Metadata $metadata, $payload)
-    {
-        return new DomainMessage($id, $playhead, $metadata, $payload, DateTime::now());
-    }
-
     /**
      * Creates a new DomainMessage with all things equal, except metadata.
      *
@@ -127,8 +25,9 @@ class DomainMessage implements DomainMessageInterface
      */
     public function andMetadata(Metadata $metadata)
     {
-        $newMetadata = $this->metadata->merge($metadata);
+        $newMetadata = $this->getMetadata()->merge($metadata);
+        $class = static::getMessageClass();
 
-        return new DomainMessage($this->id, $this->playhead, $newMetadata, $this->payload, $this->recordedOn);
+        return new $class($this->getId(), $this->getPlayhead(), $newMetadata, $this->getPayload(), $this->getRecordedOn());
     }
 }

--- a/src/Broadway/Domain/EnrichableDomainMessageInterface.php
+++ b/src/Broadway/Domain/EnrichableDomainMessageInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\Domain;
+
+/**
+ * Represents an important change in the domain that can later be enriched with more metadata.
+ */
+interface EnrichableDomainMessageInterface extends DomainMessageInterface
+{
+    /**
+     * Merges given Metadata with the current Metadata set on the Domain Message
+     *
+     * @param Metadata $metadata
+     *
+     * @return Metadata
+     */
+    public function andMetadata(Metadata $metadata);
+}

--- a/src/Broadway/Domain/RecorderInterface.php
+++ b/src/Broadway/Domain/RecorderInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\Domain;
+
+/**
+ * Adds the ability to record itself to a Domain Message
+ */
+interface RecorderInterface
+{
+    /**
+     * @param string   $id
+     * @param int      $playhead
+     * @param Metadata $metadata
+     * @param mixed    $payload
+     *
+     * @return DomainMessage
+     */
+    public static function recordNow($id, $playhead, Metadata $metadata, $payload);
+}

--- a/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnrichingEventStreamDecorator.php
+++ b/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnrichingEventStreamDecorator.php
@@ -13,6 +13,7 @@ namespace Broadway\EventSourcing\MetadataEnrichment;
 
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\EnrichableDomainMessageInterface;
 use Broadway\Domain\Metadata;
 use Broadway\EventSourcing\EventStreamDecoratorInterface;
 
@@ -48,6 +49,10 @@ class MetadataEnrichingEventStreamDecorator implements EventStreamDecoratorInter
         $messages = array();
 
         foreach ($eventStream as $message) {
+            if (!$message instanceof EnrichableDomainMessageInterface) {
+                continue;
+            }
+
             $metadata = new Metadata();
 
             foreach ($this->metadataEnrichers as $metadataEnricher) {

--- a/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnrichingEventStreamDecorator.php
+++ b/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnrichingEventStreamDecorator.php
@@ -46,6 +46,16 @@ class MetadataEnrichingEventStreamDecorator implements EventStreamDecoratorInter
             return $eventStream;
         }
 
+        return new DomainEventStream($this->processEventStream($eventStream));
+    }
+
+    /**
+     * @param DomainEventStreamInterface $eventStream
+     *
+     * @return array
+     */
+    protected function processEventStream(DomainEventStreamInterface $eventStream)
+    {
         $messages = array();
 
         foreach ($eventStream as $message) {
@@ -53,15 +63,23 @@ class MetadataEnrichingEventStreamDecorator implements EventStreamDecoratorInter
                 continue;
             }
 
-            $metadata = new Metadata();
-
-            foreach ($this->metadataEnrichers as $metadataEnricher) {
-                $metadata = $metadataEnricher->enrich($metadata);
-            }
-
-            $messages[] = $message->andMetadata($metadata);
+            $messages[] = $message->andMetadata($this->enrichMetadata());
         }
 
-        return new DomainEventStream($messages);
+        return $messages;
+    }
+
+    /**
+     * @return Metadata
+     */
+    protected function enrichMetadata()
+    {
+        $metadata = new Metadata();
+
+        foreach ($this->metadataEnrichers as $metadataEnricher) {
+            $metadata = $metadataEnricher->enrich($metadata);
+        }
+
+        return $metadata;
     }
 }

--- a/test/Broadway/Domain/DomainMessageTest.php
+++ b/test/Broadway/Domain/DomainMessageTest.php
@@ -75,8 +75,22 @@ class DomainMessageTest extends TestCase
         $expected = new Metadata(array('bar' => 1337, 'foo' => 42));
         $this->assertEquals($expected, $newMessage->getMetadata());
     }
+
+    /**
+     * @test
+     */
+    public function it_uses_parent_class_on_recording()
+    {
+        $domainMessage = NewDomainMessage::recordNow('id', 42, Metadata::kv('bar', 1337), 'payload');
+
+        $this->assertInstanceOf('Broadway\Domain\NewDomainMessage', $domainMessage);
+    }
 }
 
 class SomeEvent
+{
+}
+
+class NewDomainMessage extends DomainMessage
 {
 }


### PR DESCRIPTION
I extracted some interfaces from the `DomainMessage` and made it possible to easily use own Message implementations that can skip the (maybe expensive) enriching process. They do that by not implementing the `EnrichableDomainMessageInterface`. The BC default behavior is kept.