### PR TITLE
Rename the Event Sourcing repository's add() method to save().Fixes #114

### DIFF
--- a/examples/event-sourced-child-entity/Parts.php
+++ b/examples/event-sourced-child-entity/Parts.php
@@ -177,7 +177,7 @@ class PartCommandHandler extends Broadway\CommandHandling\CommandHandler
     {
         $part = Part::manufacture($command->partId, $command->manufacturerId, $command->manufacturerName);
 
-        $this->repository->add($part);
+        $this->repository->save($part);
     }
 
     /**
@@ -190,6 +190,6 @@ class PartCommandHandler extends Broadway\CommandHandling\CommandHandler
 
         $part->renameManufacturer($command->manufacturerName);
 
-        $this->repository->add($part);
+        $this->repository->save($part);
     }
 }

--- a/examples/event-sourced-domain-with-tests/Invites.php
+++ b/examples/event-sourced-domain-with-tests/Invites.php
@@ -198,7 +198,7 @@ class InvitationCommandHandler extends Broadway\CommandHandling\CommandHandler
     {
         $invitation = Invitation::invite($command->invitationId, $command->name);
 
-        $this->repository->add($invitation);
+        $this->repository->save($invitation);
     }
 
     /**
@@ -211,7 +211,7 @@ class InvitationCommandHandler extends Broadway\CommandHandling\CommandHandler
 
         $invitation->accept();
 
-        $this->repository->add($invitation);
+        $this->repository->save($invitation);
     }
 
     protected function handleDeclineCommand(DeclineCommand $command)
@@ -220,6 +220,6 @@ class InvitationCommandHandler extends Broadway\CommandHandling\CommandHandler
 
         $invitation->decline();
 
-        $this->repository->add($invitation);
+        $this->repository->save($invitation);
     }
 }

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -72,7 +72,7 @@ class EventSourcingRepository implements RepositoryInterface
     /**
      * {@inheritDoc}
      */
-    public function add(AggregateRoot $aggregate)
+    public function save(AggregateRoot $aggregate)
     {
         // maybe we can get generics one day.... ;)
         Assert::isInstanceOf($aggregate, $this->aggregateClass);

--- a/src/Broadway/Repository/RepositoryInterface.php
+++ b/src/Broadway/Repository/RepositoryInterface.php
@@ -23,7 +23,7 @@ interface RepositoryInterface
      *
      * @param AggregateRoot $aggregate
      */
-    public function add(AggregateRoot $aggregate);
+    public function save(AggregateRoot $aggregate);
 
     /**
      * Loads an aggregate from the given id.

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -63,7 +63,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
      */
     public function it_throws_an_exception_when_adding_an_aggregate_that_is_not_of_the_configured_class($aggregate)
     {
-        $this->repository->add($aggregate);
+        $this->repository->save($aggregate);
     }
 
     public function objectsNotOfConfiguredClass()
@@ -83,7 +83,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
         $aggregate->apply(new DidNumberEvent(42));
         $aggregate->apply(new DidNumberEvent(1337));
 
-        $this->repository->add($aggregate);
+        $this->repository->save($aggregate);
 
         $expected = array(new DidNumberEvent(42), new DidNumberEvent(1337));
         $this->assertEquals($expected, $this->eventStore->getEvents());
@@ -125,7 +125,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
         $aggregate = $this->createAggregate();
         $aggregate->apply(new DidNumberEvent(42));
 
-        $this->repository->add($aggregate);
+        $this->repository->save($aggregate);
 
         $this->assertTrue($this->eventStreamDecorator->isCalled());
     }
@@ -140,7 +140,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
         $aggregate = $this->createAggregate();
         $aggregate->apply($event);
 
-        $this->repository->add($aggregate);
+        $this->repository->save($aggregate);
 
         $lastCall = $this->eventStreamDecorator->getLastCall();
 
@@ -171,7 +171,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
 
         $aggregate = $this->createAggregate();
         $aggregate->apply(new DidNumberEvent(42));
-        $repository->add($aggregate);
+        $repository->save($aggregate);
 
         $metadata = $projector->getMetadata();
         $data     = $metadata->serialize();


### PR DESCRIPTION
Per the discussion in #114, renames the ```add()``` method to ```save()```