### PR TITLE
Fix command name in help message

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/Command/SchemaEventStoreCreateCommand.php
+++ b/src/Broadway/Bundle/BroadwayBundle/Command/SchemaEventStoreCreateCommand.php
@@ -33,10 +33,10 @@ class SchemaEventStoreCreateCommand extends DoctrineCommand
             ->setDescription('Creates the event store schema')
             ->setHelp(
 <<<EOT
-The <info>broadway:event-store:schema:init</info> command creates the schema in the default
+The <info>%command.name%</info> command creates the schema in the default
 connections database:
 
-<info>php app/console broadway:schema:event_store:create</info>
+<info>php app/console %command.name%</info>
 EOT
             );
     }

--- a/src/Broadway/Bundle/BroadwayBundle/Command/SchemaEventStoreDropCommand.php
+++ b/src/Broadway/Bundle/BroadwayBundle/Command/SchemaEventStoreDropCommand.php
@@ -33,10 +33,10 @@ class SchemaEventStoreDropCommand extends DoctrineCommand
             ->setDescription('Drops the event store schema')
             ->setHelp(
 <<<EOT
-The <info>broadway:event-store:schema:drop</info> command drops the schema in the default
+The <info>%command.name%</info> command drops the schema in the default
 connections database:
 
-<info>php app/console broadway:schema:event_store:drop</info>
+<info>php app/console %command.name%</info>
 EOT
             );
     }


### PR DESCRIPTION
Help message currently lists unavailable command `broadway:schema:event_store:create`.