### PR TITLE
Getter fot the AggregateRootInstance in the testing scenario

### DIFF
--- a/src/Broadway/EventSourcing/Testing/Scenario.php
+++ b/src/Broadway/EventSourcing/Testing/Scenario.php
@@ -121,6 +121,14 @@ class Scenario
     }
 
     /**
+     * @return Broadway\EventSourcing\EventSourcedAggregateRoot
+     */
+    public function getAggregateRootInstance()
+    {
+        return $this->aggregateRootInstance;
+    }
+
+    /**
      * @return array Payloads of the recorded events
      */
     private function getEvents()


### PR DESCRIPTION
This might be handy if you want to check that your apply methods did there job.