### PR TITLE
Make the simple event bus more resilient.

### DIFF
--- a/src/Broadway/EventHandling/SimpleEventBus.php
+++ b/src/Broadway/EventHandling/SimpleEventBus.php
@@ -12,6 +12,7 @@
 namespace Broadway\EventHandling;
 
 use Broadway\Domain\DomainEventStreamInterface;
+use Exception;
 
 /**
  * Simple synchronous publishing of events.
@@ -42,13 +43,18 @@ class SimpleEventBus implements EventBusInterface
         if (! $this->isPublishing) {
             $this->isPublishing = true;
 
-            while ($domainMessage = array_shift($this->queue)) {
-                foreach ($this->eventListeners as $eventListener) {
-                    $eventListener->handle($domainMessage);
+            try {
+                while ($domainMessage = array_shift($this->queue)) {
+                    foreach ($this->eventListeners as $eventListener) {
+                        $eventListener->handle($domainMessage);
+                    }
                 }
-            }
 
-            $this->isPublishing = false;
+                $this->isPublishing = false;
+            } catch (Exception $e) {
+                $this->isPublishing = false;
+                throw $e;
+            }
         }
     }
 }


### PR DESCRIPTION
Extremely similar to https://github.com/qandidate-labs/broadway/pull/119.

The simple event bus should be able to continue publishing events even
if an exception occurs in an event listener.