### PR TITLE
[Bundle] Make event store uuid column configurable.

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
@@ -104,8 +104,8 @@ class BroadwayExtension extends Extension
         );
 
         $container->setParameter(
-            'broadway.event_store.dbal.use_binary',
-            $config['dbal']['use_binary']
+            'broadway.event_store.dbal.uuid_type',
+            $config['dbal']['uuid_type']
         );
     }
 

--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/Configuration.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/Configuration.php
@@ -48,10 +48,14 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('table')
                                     ->defaultValue('events')
                                 ->end()
-                                ->booleanNode('use_binary')
-                                    ->defaultFalse()
+                                ->scalarNode('uuid_type')
+                                    ->defaultValue('guid')
                                     ->validate()
-                                    ->ifTrue()
+                                    ->ifNotInArray(array('guid', 'binary', 'string'))
+                                        ->thenInvalid('Invalid uuid type %s')
+                                    ->end()
+                                    ->validate()
+                                    ->ifInArray(array('binary'))
                                         ->then(function ($v) {
                                             if (Version::compare('2.5.0') >= 0) {
                                                 throw new InvalidConfigurationException(

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/event_store.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/event_store.xml
@@ -10,7 +10,7 @@
             <argument type="service" id="broadway.serializer.payload" />
             <argument type="service" id="broadway.serializer.metadata" />
             <argument>%broadway.event_store.dbal.table%</argument>
-            <argument>%broadway.event_store.dbal.use_binary%</argument>
+            <argument>%broadway.event_store.dbal.uuid_type%</argument>
         </service>
 
         <service id="broadway.event_store.in_memory" class="Broadway\EventStore\InMemoryEventStore" />

--- a/test/Broadway/EventStore/BinaryDBALEventStoreTest.php
+++ b/test/Broadway/EventStore/BinaryDBALEventStoreTest.php
@@ -32,7 +32,13 @@ class BinaryDBALEventStoreTest extends DBALEventStoreTest
         $connection       = DriverManager::getConnection(array('driver' => 'pdo_sqlite', 'memory' => true));
         $schemaManager    = $connection->getSchemaManager();
         $schema           = $schemaManager->createSchema();
-        $this->eventStore = new DBALEventStore($connection, new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), 'events', true);
+        $this->eventStore = new DBALEventStore(
+            $connection,
+            new SimpleInterfaceSerializer(),
+            new SimpleInterfaceSerializer(),
+            'events',
+            'binary'
+        );
 
         $this->table = $this->eventStore->configureSchema($schema);
 

--- a/test/Broadway/EventStore/DBALEventStoreTest.php
+++ b/test/Broadway/EventStore/DBALEventStoreTest.php
@@ -21,7 +21,13 @@ class DBALEventStoreTest extends EventStoreTest
         $connection       = DriverManager::getConnection(array('driver' => 'pdo_sqlite', 'memory' => true));
         $schemaManager    = $connection->getSchemaManager();
         $schema           = $schemaManager->createSchema();
-        $this->eventStore = new DBALEventStore($connection, new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), 'events');
+        $this->eventStore = new DBALEventStore(
+            $connection,
+            new SimpleInterfaceSerializer(),
+            new SimpleInterfaceSerializer(),
+            'events',
+            'guid'
+        );
 
         $table = $this->eventStore->configureSchema($schema);
         $schemaManager->createTable($table);


### PR DESCRIPTION
With this change, one can configure the type of the uuid column in the
`DbalEventStore`.

The configuration option is
```
broadway:
    event_store:
        dbal:
            uuid_type: guid
```
Possible values are `guid` (default), `string` or `binary`.

It replaces the `useBinary` config option, but keeps the validation if the `binary` type is used.

I wrote this PR quickly just to know if that's something you would be interested in. My use case is that I use `string` uuids in my test suite fixtures, which makes debugging a bit easier, and tests more readable.