### PR TITLE
Event sourced multiple dyanmic child entities example

### DIFF
--- a/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
@@ -1,0 +1,308 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+/**
+ * JobSeeker aggregate root
+ */
+class JobSeeker extends Broadway\EventSourcing\EventSourcedAggregateRoot
+{
+    private $jobSeekerId;
+    private $jobs = [];
+
+    /**
+     * Factory method to create a job seeker.
+     */
+    public static function startLookingForWork($jobSeekerId)
+    {
+        $jobSeeker = new JobSeeker();
+
+        // After instantiation of the object we apply the "JobSeekerStartedLookingForWorkEvent".
+        $jobSeeker->apply(new JobSeekerStartedLookingForWorkEvent($jobSeekerId));
+
+        return $jobSeeker;
+    }
+
+    /**
+     * Every aggregate root will expose its id.
+     *
+     * @return string
+     */
+    public function getAggregateRootId()
+    {
+        return $this->jobSeekerId;
+    }
+
+    public function heldJob($jobId, $title, $description)
+    {
+        if (array_key_exists($jobId, $this->jobs)) {
+            throw new \InvalidArgumentException("Job {$jobId} already assigned to this job seeker.");
+        }
+        $this->apply(new JobWasAddedToJobSeekerEvent($this->jobSeekerId, $jobId, $title, $description));
+    }
+
+    public function removeAccidentallyAddedJob($jobId)
+    {
+        $this->apply(new AccidentallyAddedJobWasRemovedFromJobSeekerEvent($this->jobSeekerId, $jobId));
+    }
+
+    public function describeJob($jobId, $title, $description)
+    {
+        if (! array_key_exists($jobId, $this->jobs)) {
+            throw new \InvalidArgumentException("Job {$jobId} is not assigned to this job seeker.");
+        }
+        $this->jobs[$jobId]->describe($title, $description);
+    }
+
+    public function applyJobSeekerStartedLookingForWorkEvent(JobSeekerStartedLookingForWorkEvent $event)
+    {
+        $this->jobSeekerId = $event->jobSeekerId;
+    }
+
+    public function applyJobWasAddedToJobSeekerEvent(JobWasAddedToJobSeekerEvent $event)
+    {
+        $this->jobs[$event->jobId] = new Job(
+            $event->jobSeekerId,
+            $event->jobId,
+            $event->title,
+            $event->description
+        );
+    }
+
+    public function applyAccidentallyAddedJobWasRemovedFromJobSeekerEvent(
+        AccidentallyAddedJobWasRemovedFromJobSeekerEvent $event
+    ) {
+        unset($this->jobs[$event->jobId]);
+    }
+
+    protected function getChildEntities()
+    {
+        return $this->jobs;
+    }
+}
+
+class Job extends Broadway\EventSourcing\EventSourcedEntity
+{
+    private $jobSeekerId;
+    private $jobId;
+    private $title;
+    private $description;
+
+    public function __construct($jobSeekerId, $jobId, $title, $description)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+        $this->jobId       = $jobId;
+        $this->title       = $title;
+        $this->description = $description;
+    }
+
+    public function describe($title, $description)
+    {
+        if ($title === $this->title && $description === $this->description) {
+            // If there is no change to the title and description we do not need to
+            // generate an event.
+            return;
+        }
+
+        $this->apply(new JobWasDescribedForJobSeekerEvent(
+            $this->jobSeekerId,
+            $this->jobId,
+            $title,
+            $description
+        ));
+    }
+
+    public function applyJobWasDescribedForJobSeekerEvent(JobWasDescribedForJobSeekerEvent $event)
+    {
+        if ($event->jobId !== $this->jobId) {
+            // Make sure that we only apply events that are intended for
+            // *this* job instance and no others.
+            return;
+        }
+
+        $this->title = $event->title;
+        $this->description = $event->description;
+    }
+}
+
+class JobSeekerStartLookingForWorkCommand
+{
+    public $jobSeekerId;
+
+    public function __construct($jobSeekerId)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+    }
+}
+
+class JobSeekerStartedLookingForWorkEvent
+{
+    public $jobSeekerId;
+
+    public function __construct($jobSeekerId)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+    }
+}
+
+class AddJobToJobSeekerCommand
+{
+    public $jobSeekerId;
+    public $jobId;
+    public $title;
+    public $description;
+
+    public function __construct($jobSeekerId, $jobId, $title, $description)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+        $this->jobId       = $jobId;
+        $this->title       = $title;
+        $this->description = $description;
+    }
+}
+
+class JobWasAddedToJobSeekerEvent
+{
+    public $jobSeekerId;
+    public $jobId;
+    public $title;
+    public $description;
+
+    public function __construct($jobSeekerId, $jobId, $title, $description)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+        $this->jobId       = $jobId;
+        $this->title       = $title;
+        $this->description = $description;
+    }
+}
+
+class DescribeJobForJobSeekerCommand
+{
+    public $jobSeekerId;
+    public $jobId;
+    public $title;
+    public $description;
+
+    public function __construct($jobSeekerId, $jobId, $title, $description)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+        $this->jobId       = $jobId;
+        $this->title       = $title;
+        $this->description = $description;
+    }
+}
+
+class JobWasDescribedForJobSeekerEvent
+{
+    public $jobSeekerId;
+    public $jobId;
+    public $title;
+    public $description;
+
+    public function __construct($jobSeekerId, $jobId, $title, $description)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+        $this->jobId       = $jobId;
+        $this->title       = $title;
+        $this->description = $description;
+    }
+}
+
+class RemoveAccidentallyAddedJobFromJobSeekerCommand
+{
+    public $jobSeekerId;
+    public $jobId;
+
+    public function __construct($jobSeekerId, $jobId)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+        $this->jobId       = $jobId;
+    }
+}
+
+class AccidentallyAddedJobWasRemovedFromJobSeekerEvent
+{
+    public $jobSeekerId;
+    public $jobId;
+
+    public function __construct($jobSeekerId, $jobId)
+    {
+        $this->jobSeekerId = $jobSeekerId;
+        $this->jobId       = $jobId;
+    }
+}
+
+/**
+ * A repository that will only store and retrieve JobSeeker aggregate roots.
+ */
+class JobSeekerRepository extends Broadway\EventSourcing\EventSourcingRepository
+{
+    public function __construct(Broadway\EventStore\EventStoreInterface $eventStore, Broadway\EventHandling\EventBusInterface $eventBus)
+    {
+        parent::__construct($eventStore, $eventBus, 'JobSeeker', new Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory());
+    }
+}
+
+/*
+ * A command handler will be registered with the command bus and handle the
+ * commands that are dispatched.
+ */
+class JobSeekerCommandHandler extends Broadway\CommandHandling\CommandHandler
+{
+    private $repository;
+
+    public function __construct(Broadway\EventSourcing\EventSourcingRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * A new job seeker aggregate root is created and added to the repository.
+     */
+    protected function handleJobSeekerStartLookingForWorkCommand(JobSeekerStartLookingForWorkCommand $command)
+    {
+        $jobSeeker = JobSeeker::startLookingForWork($command->jobSeekerId);
+
+        $this->repository->save($jobSeeker);
+    }
+
+    /**
+     * An existing job seeker aggregate root is loaded and heldJob() is
+     * called.
+     */
+    protected function handleAddJobToJobSeekerCommand(AddJobToJobSeekerCommand $command)
+    {
+        $jobSeeker = $this->repository->load($command->jobSeekerId);
+
+        $jobSeeker->heldJob($command->jobId, $command->title, $command->description);
+
+        $this->repository->save($jobSeeker);
+    }
+
+    /**
+     * An existing job seeker aggregate root is loaded and describeJob() is
+     * called.
+     */
+    protected function handleDescribeJobForJobSeekerCommand(DescribeJobForJobSeekerCommand $command)
+    {
+        $jobSeeker = $this->repository->load($command->jobSeekerId);
+
+        $jobSeeker->describeJob($command->jobId, $command->title, $command->description);
+
+        $this->repository->save($jobSeeker);
+    }
+
+    /**
+     * An existing job seeker aggregate root is loaded and removeAccidentallyAddedJob()
+     * is called.
+     */
+    protected function handleRemoveAccidentallyAddedJobFromJobSeekerCommand(RemoveAccidentallyAddedJobFromJobSeekerCommand $command)
+    {
+        $jobSeeker = $this->repository->load($command->jobSeekerId);
+
+        $jobSeeker->removeAccidentallyAddedJob($command->jobId);
+
+        $this->repository->save($jobSeeker);
+    }
+}

--- a/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekersTest.php
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekersTest.php
@@ -1,0 +1,202 @@
+<?php
+
+require_once __DIR__ . '/JobSeekers.php';
+
+/**
+ * We drive the tests of our aggregate root through the command handler.
+ *
+ * A command handler scenario consists of three steps:
+ *
+ * - First, the scenario is setup with a history of events that already took place.
+ * - Second, a command is dispatched (this is handled by the command handler)
+ * - Third, the outcome is asserted. This can either be 1) some events are
+ *   recorded, or 2) an exception is thrown.
+ */
+class JobSeekersCommandHandlerTest extends Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase
+{
+    private $generator;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();
+    }
+
+    protected function createCommandHandler(Broadway\EventStore\EventStoreInterface $eventStore, Broadway\EventHandling\EventBusInterface $eventBus)
+    {
+        $repository = new JobSeekerRepository($eventStore, $eventBus);
+
+        return new JobSeekerCommandHandler($repository);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_start_looking_for_work()
+    {
+        $id = $this->generator->generate();
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([])
+            ->when(new JobSeekerStartLookingForWorkCommand($id))
+            ->then([new JobSeekerStartedLookingForWorkEvent($id)]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_a_job()
+    {
+        $id = $this->generator->generate();
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([new JobSeekerStartedLookingForWorkEvent($id)])
+            ->when(new AddJobToJobSeekerCommand($id, 'job-000', 'Title Zero', 'Description for zero.'))
+            ->then([new JobWasAddedToJobSeekerEvent($id, 'job-000', 'Title Zero', 'Description for zero.')]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_describe_a_job()
+    {
+        $id = $this->generator->generate();
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([
+                new JobSeekerStartedLookingForWorkEvent($id),
+                new JobWasAddedToJobSeekerEvent($id, 'job-000', 'Title Zero', 'Description for zero.'),
+            ])
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-000', 'Title Double-Oh-Zero', 'Description for zero.'))
+            ->then([new JobWasDescribedForJobSeekerEvent($id, 'job-000', 'Title Double-Oh-Zero', 'Description for zero.')]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_applies_the_describe_event_to_the_correct_job()
+    {
+        $id = $this->generator->generate();
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([
+                new JobSeekerStartedLookingForWorkEvent($id),
+                new JobWasAddedToJobSeekerEvent($id, 'job-000', 'Title Zero', 'Description for zero.'),
+                new JobWasAddedToJobSeekerEvent($id, 'job-001', 'Title One', 'Description for one.'),
+                new JobWasAddedToJobSeekerEvent($id, 'job-002', 'Title Two', 'Description for two.'),
+            ])
+
+            //
+            // Trying to describe jobs with the same name and description should result in no new events since
+            // our logic dictates that we ignore describe calls that do not change either the title or the
+            // description.
+            //
+
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-000', 'Title Zero', 'Description for zero.'))
+            ->then([])
+
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-001', 'Title One', 'Description for one.'))
+            ->then([])
+
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-002', 'Title Two', 'Description for two.'))
+            ->then([])
+
+
+            //
+            // Describing one of the jobs with a different title or description should trigger a job was described
+            // event. We have already tested for that and we know it works. What we want to test for now is that the
+            // event is only being applied to the instance we expect.
+            //
+
+            // Describe job-001 with a new title and description and we expect that the event will be triggered.
+
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-001', 'Title Double-Oh-ONE!', 'Description for the one.'))
+            ->then([new JobWasDescribedForJobSeekerEvent($id, 'job-001', 'Title Double-Oh-ONE!', 'Description for the one.')])
+
+
+            // Next we describe our other two jobs with the previously specified title and description. If our
+            // apply logic is correct, the title and description should still be the same and we should not get
+            // a new event.
+
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-000', 'Title Zero', 'Description for zero.'))
+            ->then([])
+
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-002', 'Title Two', 'Description for two.'))
+            ->then([])
+
+
+            // Lastly, we make one final check to see what happens when we describe job-001 again with the original
+            // title and description from what it was first added. Since these values are different, we should see
+            // one more describe event to set things back to normal.
+
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-001', 'Title One', 'Description for one.'))
+            ->then([new JobWasDescribedForJobSeekerEvent($id, 'job-001', 'Title One', 'Description for one.')])
+
+        ;
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_remove_an_accidentally_added_job()
+    {
+        $id = $this->generator->generate();
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([
+                new JobSeekerStartedLookingForWorkEvent($id),
+                new JobWasAddedToJobSeekerEvent($id, 'job-000', 'Title Zero', 'Description for zero.'),
+                new JobWasAddedToJobSeekerEvent($id, 'job-001', 'Title One OOPS!', 'Description for one ooops.'),
+                new JobWasAddedToJobSeekerEvent($id, 'job-002', 'Title Two', 'Description for two.'),
+            ])
+            ->when(new RemoveAccidentallyAddedJobFromJobSeekerCommand($id, 'job-001'))
+            ->then([new AccidentallyAddedJobWasRemovedFromJobSeekerEvent($id, 'job-001')])
+
+            // To ensure that this command was successful, we try to add the job again. If the job can be added again
+            // we know that the removal worked.
+            ->when(new AddJobToJobSeekerCommand($id, 'job-001', 'Title Double-Oh-One!', 'Description for the one.'))
+            ->then([new JobWasAddedToJobSeekerEvent($id, 'job-001', 'Title Double-Oh-One!', 'Description for the one.')])
+
+        ;
+    }
+
+    /**
+     * @test
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage Job job-000 already assigned to this job seeker.
+     */
+    public function it_cannot_add_the_same_job_if_job_is_already_assigned()
+    {
+        $id = $this->generator->generate();
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([
+                new JobSeekerStartedLookingForWorkEvent($id),
+                new JobWasAddedToJobSeekerEvent($id, 'job-000', 'Title Zero', 'Description for zero.'),
+            ])
+            ->when(new AddJobToJobSeekerCommand($id, 'job-000', 'Title Double-Oh-Zero!', 'Description for the zero.'))
+            ->then([]);
+    }
+
+    /**
+     * @test
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage Job job-000 is not assigned to this job seeker.
+     */
+    public function it_cannot_describe_a_job_it_knows_nothing_about()
+    {
+        $id = $this->generator->generate();
+
+        $this->scenario
+            ->withAggregateId($id)
+            ->given([new JobSeekerStartedLookingForWorkEvent($id)])
+            ->when(new DescribeJobForJobSeekerCommand($id, 'job-000', 'Title Double-Oh-Zero', 'Description for zero.'))
+            ->then([]);
+    }
+}

--- a/examples/event-sourced-multiple-dyanmic-child-entities/README.md
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/README.md
@@ -36,7 +36,7 @@ moved correctly.
 Running Tests
 -------------
 
-The PHPUnit tests can be run by changing to the directory of the tests and running:
+The PHPUnit tests can be run by changing to this directory and running:
 
 ```bash
 $ phpunit .

--- a/examples/event-sourced-multiple-dyanmic-child-entities/README.md
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/README.md
@@ -9,6 +9,33 @@ suite to test the domain.
 
 The two files contain comments about what is happening.
 
+
+The Story
+---------
+
+The purpose of this example is to show how dynamically created Child Entities of
+an Aggregate Root can be managed. Compare this to a Child Entity whose entire
+lifecycle is completely tied to its parent Aggregate Root where it is created
+when the Aggregate Root itself is created.
+
+In this contrived domain, a Job Seeker may have held zero or more Jobs. Jobs
+can have a title and a description and can be removed from the Job Seeker if
+they are added accidentally. Jobs may also be described after they have been
+held in case typos are made.
+
+The example shows how to manage the creation of new Child Entities (Jobs), how
+to modify Child Entities with events, how to ensure that the correct Child
+Entities are updated when Events are applied, and how to remove Child Entities
+if needed.
+
+The tests show how the domain can be exercised using commands. It also shows
+how to test to ensure that Child Entities are being created, managed, and
+moved correctly.
+
+
+Running Tests
+-------------
+
 The PHPUnit tests can be run by changing to the directory of the tests and running:
 
 ```bash

--- a/examples/event-sourced-multiple-dyanmic-child-entities/README.md
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/README.md
@@ -1,0 +1,23 @@
+Event sourced multiple dynamic child entities with tests
+========================================================
+
+A small example of an implementation of a small domain model that includes an
+aggregate root that maintains a collection of child entities. The example
+consists of two files. The first file `JobSeekers` contains the implementation
+of the domain model. The second file `JobSeekersTest` contains a PHPUnit test
+suite to test the domain.
+
+The two files contain comments about what is happening.
+
+The PHPUnit tests can be run by changing to the directory of the tests and running:
+
+```bash
+$ phpunit .
+PHPUnit 4.1.0 by Sebastian Bergmann.
+
+.......
+
+Time: 70 ms, Memory: 4.00Mb
+
+OK (7 tests, 9 assertions)
+```


### PR DESCRIPTION
Hopefully the general idea of this example makes sense and is easy to follow. Someone looking for a job ( Job Seeker ) can claim to have held Jobs at some point. Jobs have a title and description and can be described again after they've been added. The idea being that the *job itself* was not changed, but only the description.

This shows how one can dynamically manage child entities for an AR including creating them, updating them (and the tricks involved there) and then removing them.