### PR TITLE
Allow traceable event store to clear its recorded events.

### DIFF
--- a/src/Broadway/CommandHandling/Testing/Scenario.php
+++ b/src/Broadway/CommandHandling/Testing/Scenario.php
@@ -102,6 +102,8 @@ class Scenario
     {
         $this->testCase->assertEquals($events, $this->eventStore->getEvents());
 
+        $this->eventStore->clearEvents();
+
         return $this;
     }
 }

--- a/src/Broadway/EventStore/TraceableEventStore.php
+++ b/src/Broadway/EventStore/TraceableEventStore.php
@@ -71,4 +71,12 @@ class TraceableEventStore implements EventStoreInterface
     {
         $this->tracing = true;
     }
+
+    /**
+     * Clear any previously recorded events.
+     */
+    public function clearEvents()
+    {
+        $this->recorded = array();
+    }
 }


### PR DESCRIPTION
I cherry-picked code from #146 to try and get those changes in without having to wait for deciding how examples will be handled going forward.

The idea here is that if you are doing `then()` in your tests any accumulated / recorded / stored events will be flushed so that you can do another `when()` without having to continue to append the same set of previously recorded events on subsequent `then()` calls.

Before:

```php
<?php

$this->scenario
    ->given([$eventZero])

    ->when($commandOne)
    ->then([$eventFromCommandOne])

    ->when($commandTwo)
    ->then([
        $eventFromCommandOne,
        $eventFromCommandTwo,
    ])

    ->when($commandThree)
    ->then([
        $eventFromCommandOne,
        $eventFromCommandTwo,
        $eventFromCommandThree,
    ])
;
```

... after ...


```php
<?php

$this->scenario
    ->given([$eventZero])

    ->when($commandOne)
    ->then([$eventFromCommandOne])

    ->when($commandTwo)
    ->then([$eventFromCommandTwo])

    ->when($commandThree)
    ->then([$eventFromCommandThree])
;
```

Useful for helping to make sure that commands that should not result in any events on subsequent calls is not actually resulting in any events:

```php
<?php

$this->scenario
    ->given([$eventZero])

    ->when($commandOne)
    ->then([$eventFromCommandOne])

    // Command one is not expected to result in any events
    // (maybe applying the same command should result in no state change?)
    ->when($commandOne)
    ->then([])
;
```
