### PR TITLE
Fix string conversion of Saga name in thrown error message

### DIFF
--- a/src/Broadway/Saga/Metadata/StaticallyConfiguredSagaMetadataFactory.php
+++ b/src/Broadway/Saga/Metadata/StaticallyConfiguredSagaMetadataFactory.php
@@ -24,7 +24,7 @@ class StaticallyConfiguredSagaMetadataFactory implements MetadataFactoryInterfac
 
         if (! is_subclass_of($saga, $requiredInterface)) {
             throw new RuntimeException(
-                sprintf('Provided saga of class %s must implement %s', $saga, $requiredInterface)
+                sprintf('Provided saga of class %s must implement %s', get_class($saga), $requiredInterface)
             );
         }
 


### PR DESCRIPTION
StaticallyConfiguredSagaMetadataFactory was not properly throwing a ```\RuntimeException()``` if a saga did not implement. Instead PHP was issuing a fatal error when creating the exception message to throw:

```
Object of class Path\To\MySaga could not be converted to string

/my/path/vendor/broadway/broadway/src/Broadway/Saga/Metadata/StaticallyConfiguredSagaMetadataFactory.php:27
```