### PR TITLE
replace rhumsaa/uuid by ramsey/uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "beberlei/assert": "~2.0",
         "broadway/uuid-generator": "~0.1.0",
         "php": ">=5.3.3",
-        "rhumsaa/uuid": "~2.4"
+        "ramsey/uuid": "~2.4"
     },
     "authors": [
       {


### PR DESCRIPTION
it's the same repository behind.

this commit will prevent the line bellow to be display each times you install this lib

```
Package rhumsaa/uuid is abandoned, you should avoid using it. Use ramsey/uuid instead
```