### PR TITLE
AbstractEventSourcingRepositoryTest didnt use the correct class

### DIFF
--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -164,7 +164,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
         $repository = new EventSourcingRepository(
             $this->eventStore,
             $this->eventBus,
-            '\Broadway\EventSourcing\TestEventSourcedAggregate',
+            get_class($this->createAggregate()),
             new PublicConstructorAggregateFactory(),
             array(new MetadataEnrichingEventStreamDecorator(array(new TestDecorationMetadataEnricher())))
         );


### PR DESCRIPTION
Ran into this when running tests separately, The TestEvenSourcedAggregate it is referring to is in `test/Broadway/EventSourcing/EventSourcingRepositoryTest.php`.