### PR TITLE
Solve issues with saga implementation

### DIFF
--- a/examples/saga/README.md
+++ b/examples/saga/README.md
@@ -1,0 +1,53 @@
+What's a saga?
+==============
+
+A [saga](http://cqrs.nu/Faq/sagas) is a "long running" process. It allows you 
+to keep track of a (business) transaction that usually spans multiple requests.
+A saga can be seen as a [process 
+manager](http://www.enterpriseintegrationpatterns.com/ProcessManager.html), 
+which coordinates a particular message flow, possibly across bounded contexts.
+While listening to events it can decide to dispatch new commands. In order to 
+make that decision, a saga can resort to its own state.
+
+Sagas in Broadway
+-----------------
+
+In Broadway, a saga is a class that extends `Broadway\Saga\Saga`. It uses the 
+same conventions for listening to events (i.e. it has `handle*()` methods for 
+each event it's interested in). Instead of a `DomainMessage` instance, each
+of the `handle*()` methods receives a `Broadway\Saga\State` object as the
+second argument.
+
+A `handle*()` method should always return a `State` object, which will be 
+persisted afterwards. The `State` object can be used to store anything that's
+needed to retrieve the state of the saga later, or to create new commands. 
+
+Because a saga dispatches new commands, it usually accepts the command bus as 
+its first constructor argument. And since it probably needs fresh UUIDs when 
+dispatching new commands, it likely needs a UUID generator as well. The rest 
+is up to you.
+
+Sample code
+-----------
+
+The code in `ReservationSaga.php` is based on an example from the book 
+[Exploring CQRS and event sourcing (Microsoft patterns & 
+practices)[(https://msdn.microsoft.com/en-us/library/jj554200.aspx).
+
+Whenever an order is placed, a reservation is made for the requested number 
+of seats. When this reservation was accepted (i.e. the number of requested 
+seats didn't exceed the number of available seats), the order itself is marked 
+as "booked". When the reservation was rejected, the order itself is rejected.
+
+Please refer to [this 
+diagram](https://msdn.microsoft.com/en-us/library/JJ591570.20afccbda270dfd4b9cf0ffac4249b9b%28l=en-us%29.png) 
+for a full overview of the different situations that might occur.
+
+Also, take a look at the tests in `ReservationSagaTest.php` to see how you can
+prove that your saga implementation is sound.
+
+The PHPUnit tests can be run by changing to this directory and running:
+
+```bash
+phpunit .
+```

--- a/examples/saga/ReservationSaga.php
+++ b/examples/saga/ReservationSaga.php
@@ -1,0 +1,197 @@
+<?php
+
+require __DIR__ . '/../bootstrap.php';
+
+use Broadway\CommandHandling\CommandBusInterface;
+use Broadway\Saga\Metadata\StaticallyConfiguredSagaInterface;
+use Broadway\Saga\Saga;
+use Broadway\Saga\State;
+use Broadway\Saga\State\Criteria;
+use Broadway\UuidGenerator\UuidGeneratorInterface;
+
+class ReservationSaga extends Saga implements StaticallyConfiguredSagaInterface
+{
+    private $commandBus;
+    private $uuidGenerator;
+
+    public function __construct(
+        CommandBusInterface $commandBus,
+        UuidGeneratorInterface $uuidGenerator
+    ) {
+        $this->commandBus = $commandBus;
+        $this->uuidGenerator = $uuidGenerator;
+    }
+
+    public static function configuration()
+    {
+        return array(
+            'OrderPlaced' => function (OrderPlaced $event) {
+                return null; // no criteria, start of a new saga
+            },
+            'ReservationAccepted' => function (ReservationAccepted $event) {
+                // return a Criteria object to fetch the State of this saga
+                return new Criteria(array(
+                    'reservationId' => $event->reservationId()
+                ));
+            },
+            'ReservationRejected' => function (ReservationRejected $event) {
+                // return a Criteria object to fetch the State of this saga
+                return new Criteria(array(
+                    'reservationId' => $event->reservationId()
+                ));
+            }
+        );
+    }
+
+    public function handleOrderPlaced(OrderPlaced $event, State $state)
+    {
+        // keep the order id, for reference in `handleReservationAccepted()` and `handleReservationRejected()`
+        $state->set('orderId', $event->orderId());
+
+        // generate an id for the reservation
+        $reservationId = $this->uuidGenerator->generate();
+        $state->set('reservationId', $reservationId);
+
+        // make the reservation
+        $command = new MakeSeatReservation($reservationId, $event->numberOfSeats());
+        $this->commandBus->dispatch($command);
+
+        return $state;
+    }
+
+    public function handleReservationAccepted(ReservationAccepted $event, State $state)
+    {
+        // the seat reservation for the given order is has been accepted, mark the order as booked
+        $command = new MarkOrderAsBooked($state->get('orderId'));
+        $this->commandBus->dispatch($command);
+
+        // the saga ends here
+        $state->isDone();
+
+        return $state;
+    }
+
+    public function handleReservationRejected(ReservationRejected $event, State $state)
+    {
+        // the seat reservation for the given order is has been rejected, reject the order as well
+        $command = new RejectOrder($state->get('orderId'));
+        $this->commandBus->dispatch($command);
+
+        // the saga ends here
+        $state->isDone();
+
+        return $state;
+    }
+}
+
+/**
+ * event
+ */
+class OrderPlaced
+{
+    private $orderId;
+    private $numberOfSeats;
+
+    public function __construct($orderId, $numberOfSeats)
+    {
+        $this->orderId = $orderId;
+        $this->numberOfSeats = $numberOfSeats;
+    }
+
+    public function orderId()
+    {
+        return $this->orderId;
+    }
+
+    public function numberOfSeats()
+    {
+        return $this->numberOfSeats;
+    }
+}
+
+/**
+ * command
+ */
+class MakeSeatReservation
+{
+    private $reservationId;
+    private $numberOfSeats;
+
+    public function __construct($reservationId, $numberOfSeats)
+    {
+        $this->reservationId = $reservationId;
+        $this->numberOfSeats = $numberOfSeats;
+    }
+
+    public function reservationId()
+    {
+        return $this->reservationId;
+    }
+
+    public function numberOfSeats()
+    {
+        return $this->numberOfSeats;
+    }
+}
+
+/**
+ * event
+ */
+class ReservationAccepted
+{
+    private $reservationId;
+
+    public function __construct($reservationId)
+    {
+        $this->reservationId = $reservationId;
+    }
+
+    public function reservationId()
+    {
+        return $this->reservationId;
+    }
+}
+
+/**
+ * event
+ */
+class ReservationRejected
+{
+    private $reservationId;
+
+    public function __construct($reservationId)
+    {
+        $this->reservationId = $reservationId;
+    }
+
+    public function reservationId()
+    {
+        return $this->reservationId;
+    }
+}
+
+/**
+ * command
+ */
+class MarkOrderAsBooked
+{
+    private $orderId;
+
+    public function __construct($orderId)
+    {
+        $this->orderId = $orderId;
+    }
+}
+
+/**
+ * command
+ */
+class RejectOrder
+{
+    private $orderId;
+
+    public function __construct($orderId)
+    {
+        $this->orderId = $orderId;
+    }
+}

--- a/examples/saga/ReservationSagaTest.php
+++ b/examples/saga/ReservationSagaTest.php
@@ -1,0 +1,61 @@
+<?php
+
+require __DIR__ . '/ReservationSaga.php';
+
+use Broadway\CommandHandling\CommandBusInterface;
+use Broadway\Saga\Testing\SagaScenarioTestCase;
+use Broadway\UuidGenerator\Testing\MockUuidSequenceGenerator;
+
+class ReservationSagaTest extends SagaScenarioTestCase
+{
+    protected function createSaga(CommandBusInterface $commandBus)
+    {
+        return new ReservationSaga($commandBus, new MockUuidSequenceGenerator(
+            array(
+                'bf142ea0-29f7-11e5-9d3f-0002a5d5c51b'
+            )
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_makes_a_seat_reservation_when_an_order_was_placed()
+    {
+        $this->scenario
+            ->when(new OrderPlaced('9d66f760-29f7-11e5-a239-0002a5d5c51b', 5))
+            ->then(array(
+                new MakeSeatReservation('bf142ea0-29f7-11e5-9d3f-0002a5d5c51b', 5)
+            ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_marks_the_order_as_booked_when_the_seat_reservation_was_accepted()
+    {
+        $this->scenario
+            ->given(array(
+                new OrderPlaced('9d66f760-29f7-11e5-a239-0002a5d5c51b', 5)
+            ))
+            ->when(new ReservationAccepted('bf142ea0-29f7-11e5-9d3f-0002a5d5c51b'))
+            ->then(array(
+                new MarkOrderAsBooked('9d66f760-29f7-11e5-a239-0002a5d5c51b')
+            ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_the_order_when_the_seat_reservation_was_rejected()
+    {
+        $this->scenario
+            ->given(array(
+                new OrderPlaced('9d66f760-29f7-11e5-a239-0002a5d5c51b', 5)
+            ))
+            ->when(new ReservationRejected('bf142ea0-29f7-11e5-9d3f-0002a5d5c51b'))
+            ->then(array(
+                new RejectOrder('9d66f760-29f7-11e5-a239-0002a5d5c51b')
+            ));
+    }
+}

--- a/src/Broadway/Bundle/BroadwayBundle/BroadwayBundle.php
+++ b/src/Broadway/Bundle/BroadwayBundle/BroadwayBundle.php
@@ -17,6 +17,7 @@ use Broadway\Bundle\BroadwayBundle\DependencyInjection\DefineDBALEventStoreConne
 use Broadway\Bundle\BroadwayBundle\DependencyInjection\RegisterBusSubscribersCompilerPass;
 use Broadway\Bundle\BroadwayBundle\DependencyInjection\RegisterEventListenerCompilerPass;
 use Broadway\Bundle\BroadwayBundle\DependencyInjection\RegisterMetadataEnricherSubscriberPass;
+use Broadway\Bundle\BroadwayBundle\DependencyInjection\RegisterSagaCompilerPass;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -61,6 +62,12 @@ class BroadwayBundle extends Bundle
         );
         $container->addCompilerPass(
             new DefineDBALEventStoreConnectionCompilerPass($this->getContainerExtension()->getAlias())
+        );
+        $container->addCompilerPass(
+            new RegisterSagaCompilerPass(
+                'broadway.saga.multiple_saga_manager',
+                'broadway.saga'
+            )
         );
     }
 

--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterSagaCompilerPass.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterSagaCompilerPass.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Broadway\Bundle\BroadwayBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterSagaCompilerPass implements CompilerPassInterface
+{
+    private $multipleSagaManagerService;
+    private $tagName;
+
+    /**
+     * @param string $multipleSagaManagerService
+     * @param string $tagName
+     */
+    public function __construct($multipleSagaManagerService, $tagName)
+    {
+        $this->multipleSagaManagerService = $multipleSagaManagerService;
+        $this->tagName = $tagName;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has($this->multipleSagaManagerService)) {
+            throw new \LogicException(
+                sprintf('Unknown saga manager service known as %s', $this->multipleSagaManagerService)
+            );
+        }
+
+        $sagas = array();
+
+        foreach ($container->findTaggedServiceIds($this->tagName) as $serviceId => $tags) {
+            foreach ($tags as $attributes) {
+                if (!isset($attributes['type'])) {
+                    throw new \InvalidArgumentException(
+                        sprintf(
+                            'Tag "%s" of service "%s" should have a "type" attribute, indicating the type of saga it represents',
+                            $this->tagName,
+                            $serviceId
+                        )
+                    );
+                }
+
+                $type = $attributes['type'];
+                $sagas[$type] = new Reference($serviceId);
+            }
+        }
+
+        $container
+            ->findDefinition($this->multipleSagaManagerService)
+            ->replaceArgument(1, $sagas);
+    }
+}

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga.xml
@@ -18,5 +18,15 @@
             <tag name="broadway.metadata_enricher" />
         </service>
 
+        <service id="broadway.saga.multiple_saga_manager" class="Broadway\Saga\MultipleSagaManager">
+            <argument type="service" id="broadway.saga.state.repository" />
+            <!-- will be populated by RegisterSagaCompilerPass: -->
+            <argument type="collection"/>
+            <argument type="service" id="broadway.saga.state.state_manager" />
+            <argument type="service" id="broadway.saga.metadata.factory" />
+            <argument type="service" id="broadway.event_dispatcher" />
+            <tag name="broadway.domain.event_listener" />
+        </service>
+
     </services>
 </container>

--- a/src/Broadway/Bundle/README.md
+++ b/src/Broadway/Bundle/README.md
@@ -61,6 +61,18 @@ user, an ip address or some request token.
 <tag name="broadway.metadata_enricher" />
 ```
 
+### Sagas
+
+Register sagas using the `broadway.saga` service tag:
+ 
+```xml
+<service class="ReservationSaga">
+    <argument type="service" id="broadway.command_handling.command_bus" />
+    <argument type="service" id="broadway.uuid.generator" />
+    <tag name="broadway.saga" type="reservation" />
+</service>
+```
+
 ## Configuration
 
 There are some basic configuration options available at this point. The


### PR DESCRIPTION
In this PR I have so far fixed the following problems:

- Previously there was no way to register saga's automatically. I've added the `RegisterSagaCompilerPass` for this and you can use the `broadway.saga` service tag now.
- Saga instances should be provided as the second argument of the `MultipleSagaManager`, for which there was no service definition yet. I've added it.
- The `SagaScenarioTestCase` didn't conform to the other `*TestCase` classes in this library in that you had to create your own scenario. I changed this: it's now created for you. Since a saga is likely to use generated UUIDs, a sequence generator for them has been provided, so this allows you to provide a fixed set of UUIDs before running your test by calling `setGeneratedUuids()`. I have modified the API of the `MockUuidSequenceGenerator` to make this possible.
- Add a saga example, point to some references.
- Add a comment about the service tag.

Looking forward to your feedback!