### PR TITLE
Allow for event store management; query event store.

### DIFF
--- a/src/Broadway/EventStore/CallableEventVisitor.php
+++ b/src/Broadway/EventStore/CallableEventVisitor.php
@@ -11,7 +11,6 @@
 
 namespace Broadway\EventStore;
 
-
 use Broadway\Domain\DomainMessage;
 
 class CallableEventVisitor implements EventVisitorInterface

--- a/src/Broadway/EventStore/CallableEventVisitor.php
+++ b/src/Broadway/EventStore/CallableEventVisitor.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore;
+
+
+use Broadway\Domain\DomainMessage;
+
+class CallableEventVisitor implements EventVisitorInterface
+{
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    public function doWithEvent(DomainMessage $domainMessage)
+    {
+        call_user_func($this->callable, $domainMessage);
+    }
+}

--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -282,9 +282,10 @@ class DBALEventStore implements EventStoreInterface, EventStoreManagementInterfa
             $criteriaTypes[] = array('uuid IN (:uuids)');
 
             if ($this->useBinary) {
-                $bindValues['uuids'] = array_map(function ($id) {
-                    return $this->convertIdentifierToStorageValue($id);
-                }, $criteria->getAggregateRootIds());
+                $bindValues['uuids'] = array();
+                foreach ($criteria->getAggregateRootIds() as $id) {
+                    $bindValues['uuids'][] = $this->convertIdentifierToStorageValue($id);
+                }
                 $bindValueTypes['uuids'] = Connection::PARAM_STR_ARRAY;
             } else {
                 $bindValues['uuids'] = $criteria->getAggregateRootIds();

--- a/src/Broadway/EventStore/EventVisitorInterface.php
+++ b/src/Broadway/EventStore/EventVisitorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore;
+
+use Broadway\Domain\DomainMessage;
+
+interface EventVisitorInterface
+{
+    public function doWithEvent(DomainMessage $domainMessage);
+}

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -73,7 +73,7 @@ class InMemoryEventStore implements EventStoreInterface, EventStoreManagementInt
     {
         $allEvents = $this->allEvents;
         if (! is_null($criteria)) {
-            $allEvents = array_filter($allEvents, [$criteria, 'isMatchedBy']);
+            $allEvents = array_filter($allEvents, array($criteria, 'isMatchedBy'));
         }
 
         foreach ($allEvents as $event) {

--- a/src/Broadway/EventStore/Management/Criteria.php
+++ b/src/Broadway/EventStore/Management/Criteria.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+use Broadway\Domain\DomainMessage;
+
+class Criteria
+{
+    private $aggregateRootTypes = array();
+    private $aggregateRootIds = array();
+    private $eventTypes = array();
+
+    public function withAggregateRootTypes(array $aggregateRootTypes)
+    {
+        $instance = clone($this);
+        $instance->aggregateRootTypes = $aggregateRootTypes;
+
+        return $instance;
+    }
+
+    public function withAggregateRootType($aggregateRootType)
+    {
+        $instance = clone($this);
+        $instance->aggregateRootTypes = array($aggregateRootType);
+
+        return $instance;
+    }
+
+    public function withAdditionalAggregateRootType($aggregateRootType)
+    {
+        $instance = clone($this);
+        $instance->aggregateRootTypes[] = $aggregateRootType;
+
+        return $instance;
+    }
+
+    public function withAggregateRootIds(array $aggregateRootIds)
+    {
+        $instance = clone($this);
+        $instance->aggregateRootIds = $aggregateRootIds;
+
+        return $instance;
+    }
+
+    public function withAggregateRootId($aggregateRootId)
+    {
+        $instance = clone($this);
+        $instance->aggregateRootIds = array($aggregateRootId);
+
+        return $instance;
+    }
+
+    public function withAdditionalAggregateRootId($aggregateRootId)
+    {
+        $instance = clone($this);
+        $instance->aggregateRootIds[] = $aggregateRootId;
+
+        return $instance;
+    }
+
+    public function withEventTypes(array $eventTypes)
+    {
+        $instance = clone($this);
+        $instance->eventTypes = $eventTypes;
+
+        return $instance;
+    }
+
+    public function withEventType($eventType)
+    {
+        $instance = clone($this);
+        $instance->eventTypes = array($eventType);
+
+        return $instance;
+    }
+
+    public function withAdditionalEventType($eventType)
+    {
+        $instance = clone($this);
+        $instance->eventTypes[] = $eventType;
+
+        return $instance;
+    }
+
+    public function getAggregateRootTypes()
+    {
+        return $this->aggregateRootTypes;
+    }
+
+    public function getAggregateRootIds()
+    {
+        return $this->aggregateRootIds;
+    }
+
+    public function getEventTypes()
+    {
+        return $this->eventTypes;
+    }
+
+    public static function create()
+    {
+        return new static();
+    }
+
+    public function isMatchedBy(DomainMessage $domainMessage)
+    {
+        if ($this->aggregateRootTypes) {
+            throw new CriteriaNotSupportedException(
+                'Cannot match criteria based on aggregate root types.'
+            );
+        }
+
+        if ($this->aggregateRootIds && ! in_array($domainMessage->getId(), $this->aggregateRootIds)) {
+            return false;
+        }
+
+        if ($this->eventTypes && ! in_array($domainMessage->getType(), $this->eventTypes)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Broadway/EventStore/Management/Criteria.php
+++ b/src/Broadway/EventStore/Management/Criteria.php
@@ -19,6 +19,12 @@ class Criteria
     private $aggregateRootIds = array();
     private $eventTypes = array();
 
+    /**
+     * Create a new criteria with the specified aggregate root types
+     *
+     * @param array $aggregateRootTypes
+     * @return static
+     */
     public function withAggregateRootTypes(array $aggregateRootTypes)
     {
         $instance = clone($this);
@@ -27,22 +33,12 @@ class Criteria
         return $instance;
     }
 
-    public function withAggregateRootType($aggregateRootType)
-    {
-        $instance = clone($this);
-        $instance->aggregateRootTypes = array($aggregateRootType);
-
-        return $instance;
-    }
-
-    public function withAdditionalAggregateRootType($aggregateRootType)
-    {
-        $instance = clone($this);
-        $instance->aggregateRootTypes[] = $aggregateRootType;
-
-        return $instance;
-    }
-
+    /**
+     * Create a new criteria with the specified aggregate root IDs
+     *
+     * @param array $aggregateRootIds
+     * @return Criteria
+     */
     public function withAggregateRootIds(array $aggregateRootIds)
     {
         $instance = clone($this);
@@ -51,22 +47,12 @@ class Criteria
         return $instance;
     }
 
-    public function withAggregateRootId($aggregateRootId)
-    {
-        $instance = clone($this);
-        $instance->aggregateRootIds = array($aggregateRootId);
-
-        return $instance;
-    }
-
-    public function withAdditionalAggregateRootId($aggregateRootId)
-    {
-        $instance = clone($this);
-        $instance->aggregateRootIds[] = $aggregateRootId;
-
-        return $instance;
-    }
-
+    /**
+     * Create a new criteria with the specified event types
+     *
+     * @param array $eventTypes
+     * @return Criteria
+     */
     public function withEventTypes(array $eventTypes)
     {
         $instance = clone($this);
@@ -75,42 +61,52 @@ class Criteria
         return $instance;
     }
 
-    public function withEventType($eventType)
-    {
-        $instance = clone($this);
-        $instance->eventTypes = array($eventType);
-
-        return $instance;
-    }
-
-    public function withAdditionalEventType($eventType)
-    {
-        $instance = clone($this);
-        $instance->eventTypes[] = $eventType;
-
-        return $instance;
-    }
-
+    /**
+     * Get the aggregate root types for the criteria
+     *
+     * @return string[]
+     */
     public function getAggregateRootTypes()
     {
         return $this->aggregateRootTypes;
     }
 
+    /**
+     * Get the aggregate root IDs for the criteria
+     *
+     * @return array
+     */
     public function getAggregateRootIds()
     {
         return $this->aggregateRootIds;
     }
 
+    /**
+     * Get the event types for the criteria
+     *
+     * @return array
+     */
     public function getEventTypes()
     {
         return $this->eventTypes;
     }
 
+    /**
+     * Create a new criteria
+     *
+     * @return static
+     */
     public static function create()
     {
         return new static();
     }
 
+    /**
+     * Determine if a domain message is matched by this criteria
+     *
+     * @param DomainMessage $domainMessage
+     * @return bool
+     */
     public function isMatchedBy(DomainMessage $domainMessage)
     {
         if ($this->aggregateRootTypes) {

--- a/src/Broadway/EventStore/Management/CriteriaNotSupportedException.php
+++ b/src/Broadway/EventStore/Management/CriteriaNotSupportedException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+/**
+ * Criteria not supported by implementation
+ *
+ * In some cases an event store implementation may implement management
+ * but not be able to satisfy all criteria options. In this case, the
+ * implementation must throw this exception.
+ *
+ * Class CriteriaNotSupportedException
+ * @package Broadway\EventStore\Management
+ */
+class CriteriaNotSupportedException extends EventStoreManagementException
+{
+}

--- a/src/Broadway/EventStore/Management/EventStoreManagementException.php
+++ b/src/Broadway/EventStore/Management/EventStoreManagementException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+use RuntimeException;
+
+/**
+ * Exceptions thrown by event store implementations.
+ */
+abstract class EventStoreManagementException extends RuntimeException
+{
+}

--- a/src/Broadway/EventStore/Management/EventStoreManagementInterface.php
+++ b/src/Broadway/EventStore/Management/EventStoreManagementInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+use Broadway\EventStore\EventVisitorInterface;
+
+interface EventStoreManagementInterface
+{
+    public function visitEvents(EventVisitorInterface $eventVisitor, Criteria $criteria = null);
+}

--- a/src/Broadway/EventStore/Management/EventStoreManagementInterface.php
+++ b/src/Broadway/EventStore/Management/EventStoreManagementInterface.php
@@ -15,5 +15,5 @@ use Broadway\EventStore\EventVisitorInterface;
 
 interface EventStoreManagementInterface
 {
-    public function visitEvents(EventVisitorInterface $eventVisitor, Criteria $criteria = null);
+    public function visitEvents(Criteria $criteria, EventVisitorInterface $eventVisitor);
 }

--- a/test/Broadway/EventStore/Management/BinaryDBALEventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/BinaryDBALEventStoreManagementTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+use Broadway\EventStore\DBALEventStore;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Version;
+
+class BinaryDBALEventStoreManagementTest extends DBALEventStoreManagementTest
+{
+    /** @var \Doctrine\DBAL\Schema\Table  */
+    protected $table;
+
+    public function createEventStore()
+    {
+        if (Version::compare('2.5.0') >= 0) {
+            $this->markTestSkipped('Binary type is only available for Doctrine >= v2.5');
+        }
+
+        $connection       = DriverManager::getConnection(array('driver' => 'pdo_sqlite', 'memory' => true));
+        $schemaManager    = $connection->getSchemaManager();
+        $schema           = $schemaManager->createSchema();
+        $eventStore = new DBALEventStore($connection, new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), 'events', true);
+
+        $this->table = $eventStore->configureSchema($schema);
+
+        $schemaManager->createTable($this->table);
+
+        return $eventStore;
+    }
+
+}

--- a/test/Broadway/EventStore/Management/DBALEventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/DBALEventStoreManagementTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+use Broadway\EventStore\DBALEventStore;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use Doctrine\DBAL\DriverManager;
+
+class DBALEventStoreManagementTest extends EventStoreManagementTest
+{
+    public function createEventStore()
+    {
+        $connection       = DriverManager::getConnection(array('driver' => 'pdo_sqlite', 'memory' => true));
+        $schemaManager    = $connection->getSchemaManager();
+        $schema           = $schemaManager->createSchema();
+        $eventStore = new DBALEventStore($connection, new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), 'events');
+
+        $table = $eventStore->configureSchema($schema);
+        $schemaManager->createTable($table);
+
+        return $eventStore;
+    }
+}

--- a/test/Broadway/EventStore/Management/EventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/EventStoreManagementTest.php
@@ -195,17 +195,17 @@ abstract class EventStoreManagementTest extends TestCase
      */
     private function groupEventsByAggregateTypeAndId(array $events)
     {
-        $eventsByAggregateTypeAndId = [];
+        $eventsByAggregateTypeAndId = array();
         foreach ($events as $event) {
             $type = $event->getType();
             $id = $event->getId();
 
             if (! array_key_exists($type, $eventsByAggregateTypeAndId)) {
-                $eventsByAggregateTypeAndId[$type] = [];
+                $eventsByAggregateTypeAndId[$type] = array();
             }
 
             if (! array_key_exists($id, $eventsByAggregateTypeAndId[$type])) {
-                $eventsByAggregateTypeAndId[$type][$id] = [];
+                $eventsByAggregateTypeAndId[$type][$id] = array();
             }
 
             $eventsByAggregateTypeAndId[$type][$id][] = $event;

--- a/test/Broadway/EventStore/Management/EventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/EventStoreManagementTest.php
@@ -28,11 +28,16 @@ abstract class EventStoreManagementTest extends TestCase
      */
     protected $eventStore;
 
+    /**
+     * @var DateTime
+     */
+    protected $now;
+
     public function setUp()
     {
+        $this->now = DateTime::now();
         $this->eventStore = $this->createEventStore();
         $this->createAndInsertEventFixtures();
-
         $this->eventVisitor = new RecordingEventVisitor();
     }
 
@@ -265,7 +270,8 @@ abstract class EventStoreManagementTest extends TestCase
     private function createDomainMessage($id, $playhead, $event)
     {
         $id = $this->getId($id);
-        return new DomainMessage((string) $id, (string) $playhead, new Metadata(array()), $event, DateTime::now());
+
+        return new DomainMessage((string) $id, (string) $playhead, new Metadata(array()), $event, $this->now);
     }
 
     private function getId($id)

--- a/test/Broadway/EventStore/Management/EventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/EventStoreManagementTest.php
@@ -1,0 +1,342 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+use Broadway\Domain\DateTime;
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use Broadway\EventStore\EventStoreInterface;
+use Broadway\EventStore\EventVisitorInterface;
+use Broadway\EventStore\Management\EventStoreManagementInterface;
+use Broadway\Serializer\SerializableInterface;
+use Broadway\TestCase;
+
+abstract class EventStoreManagementTest extends TestCase
+{
+    /**
+     * @var EventStoreInterface|EventStoreManagementInterface
+     */
+    protected $eventStore;
+
+    public function setUp()
+    {
+        $this->eventStore = $this->createEventStore();
+        $this->createAndInsertEventFixtures();
+
+        $this->eventVisitor = new RecordingEventVisitor();
+    }
+
+    protected function visitEvents(Criteria $criteria = null)
+    {
+        $eventVisitor = new RecordingEventVisitor();
+
+        $this->eventStore->visitEvents($eventVisitor, $criteria);
+
+        return $eventVisitor->getVisitedEvents();
+    }
+
+    abstract protected function createEventStore();
+
+    /** @test */
+    public function it_visits_all_events()
+    {
+        $visitedEvents = $this->visitEvents();
+
+        $this->assertEquals($this->getEventFixtures(), $visitedEvents);
+    }
+
+    /** @test */
+    public function it_visits_aggregate_root_id()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()->withAggregateRootId(
+            $this->getId(1)
+        ));
+
+        $this->assertEquals(array(
+            $this->createDomainMessage(1, 0, new Start()),
+            $this->createDomainMessage(1, 1, new Middle('a')),
+            $this->createDomainMessage(1, 2, new Middle('b')),
+            $this->createDomainMessage(1, 3, new Middle('c')),
+            $this->createDomainMessage(1, 4, new Middle('d')),
+            $this->createDomainMessage(1, 5, new End()),
+        ), $visitedEvents);
+    }
+
+    /** @test */
+    public function it_visits_aggregate_root_ids()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()->withAggregateRootIds(array(
+            $this->getId(1),
+            $this->getId(3),
+        )));
+
+        $this->assertEquals(array(
+            $this->createDomainMessage(1, 0, new Start()),
+            $this->createDomainMessage(1, 1, new Middle('a')),
+            $this->createDomainMessage(1, 2, new Middle('b')),
+            $this->createDomainMessage(1, 3, new Middle('c')),
+            $this->createDomainMessage(3, 0, new Start()),
+            $this->createDomainMessage(3, 1, new Middle('a')),
+            $this->createDomainMessage(3, 2, new Middle('b')),
+            $this->createDomainMessage(3, 3, new Middle('c')),
+            $this->createDomainMessage(1, 4, new Middle('d')),
+            $this->createDomainMessage(3, 4, new Middle('d')),
+            $this->createDomainMessage(1, 5, new End()),
+            $this->createDomainMessage(3, 5, new End()),
+        ), $visitedEvents);
+    }
+
+    /** @test */
+    public function it_visits_additional_aggregate_root_ids()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()
+            ->withAggregateRootId($this->getId(1))
+            ->withAdditionalAggregateRootId($this->getId(3))
+        );
+
+        $this->assertEquals(array(
+            $this->createDomainMessage(1, 0, new Start()),
+            $this->createDomainMessage(1, 1, new Middle('a')),
+            $this->createDomainMessage(1, 2, new Middle('b')),
+            $this->createDomainMessage(1, 3, new Middle('c')),
+            $this->createDomainMessage(3, 0, new Start()),
+            $this->createDomainMessage(3, 1, new Middle('a')),
+            $this->createDomainMessage(3, 2, new Middle('b')),
+            $this->createDomainMessage(3, 3, new Middle('c')),
+            $this->createDomainMessage(1, 4, new Middle('d')),
+            $this->createDomainMessage(3, 4, new Middle('d')),
+            $this->createDomainMessage(1, 5, new End()),
+            $this->createDomainMessage(3, 5, new End()),
+        ), $visitedEvents);
+    }
+
+    /** @test */
+    public function it_visits_event_type()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()
+            ->withEventType('Broadway.EventStore.Management.Start')
+        );
+
+        $this->assertEquals(array(
+            $this->createDomainMessage(1, 0, new Start()),
+            $this->createDomainMessage(2, 0, new Start()),
+            $this->createDomainMessage(3, 0, new Start()),
+            $this->createDomainMessage(4, 0, new Start()),
+        ), $visitedEvents);
+    }
+
+    /** @test */
+    public function it_visits_event_types()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()
+            ->withEventTypes(array(
+                'Broadway.EventStore.Management.Start',
+                'Broadway.EventStore.Management.End',
+            ))
+        );
+
+        $this->assertEquals(array(
+            $this->createDomainMessage(1, 0, new Start()),
+            $this->createDomainMessage(2, 0, new Start()),
+            $this->createDomainMessage(2, 5, new End()),
+            $this->createDomainMessage(3, 0, new Start()),
+            $this->createDomainMessage(4, 0, new Start()),
+            $this->createDomainMessage(4, 5, new End()),
+            $this->createDomainMessage(1, 5, new End()),
+            $this->createDomainMessage(3, 5, new End()),
+        ), $visitedEvents);
+    }
+
+    /** @test */
+    public function it_visits_additional_event_types()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()
+            ->withEventType('Broadway.EventStore.Management.Start')
+            ->withAdditionalEventType('Broadway.EventStore.Management.End')
+        );
+
+        $this->assertEquals(array(
+            $this->createDomainMessage(1, 0, new Start()),
+            $this->createDomainMessage(2, 0, new Start()),
+            $this->createDomainMessage(2, 5, new End()),
+            $this->createDomainMessage(3, 0, new Start()),
+            $this->createDomainMessage(4, 0, new Start()),
+            $this->createDomainMessage(4, 5, new End()),
+            $this->createDomainMessage(1, 5, new End()),
+            $this->createDomainMessage(3, 5, new End()),
+        ), $visitedEvents);
+    }
+
+    /**
+     * @test
+     * @expectedException \Broadway\EventStore\Management\CriteriaNotSupportedException
+     */
+    public function it_visits_aggregate_root_type()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()
+            ->withAggregateRootType('Broadway.EventStore.Management.AggregateTypeOne')
+        );
+    }
+
+    /**
+     * @test
+     * @expectedException \Broadway\EventStore\Management\CriteriaNotSupportedException
+     */
+    public function it_visits_aggregate_root_types()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()
+            ->withAggregateRootTypes(array(
+                'Broadway.EventStore.Management.AggregateTypeOne',
+                'Broadway.EventStore.Management.AggregateTypeTwo',
+            ))
+        );
+    }
+
+    /**
+     * @test
+     * @expectedException \Broadway\EventStore\Management\CriteriaNotSupportedException
+     */
+    public function it_visits_additional_aggregate_root_types()
+    {
+        $visitedEvents = $this->visitEvents(Criteria::create()
+            ->withAggregateRootType('Broadway.EventStore.Management.AggregateTypeOne')
+            ->withAdditionalAggregateRootType('Broadway.EventStore.Management.AggregateTypeTwo')
+        );
+    }
+
+    private function createAndInsertEventFixtures()
+    {
+        foreach ($this->getEventFixtures() as $domainMessage) {
+            $this->eventStore->append($domainMessage->getId(), new DomainEventStream(array($domainMessage)));
+        }
+    }
+
+    /**
+     * @return DomainMessage[]
+     */
+    protected function getEventFixtures()
+    {
+        return array(
+            $this->createDomainMessage(1, 0, new Start()),
+            $this->createDomainMessage(1, 1, new Middle('a')),
+            $this->createDomainMessage(1, 2, new Middle('b')),
+
+            $this->createDomainMessage(2, 0, new Start()),
+            $this->createDomainMessage(2, 1, new Middle('a')),
+            $this->createDomainMessage(2, 2, new Middle('b')),
+            $this->createDomainMessage(2, 3, new Middle('c')),
+            $this->createDomainMessage(2, 4, new Middle('d')),
+            $this->createDomainMessage(2, 5, new End()),
+
+            $this->createDomainMessage(1, 3, new Middle('c')),
+
+            $this->createDomainMessage(3, 0, new Start()),
+            $this->createDomainMessage(3, 1, new Middle('a')),
+            $this->createDomainMessage(3, 2, new Middle('b')),
+            $this->createDomainMessage(3, 3, new Middle('c')),
+
+            $this->createDomainMessage(1, 4, new Middle('d')),
+
+            $this->createDomainMessage(4, 0, new Start()),
+            $this->createDomainMessage(4, 1, new Middle('a')),
+            $this->createDomainMessage(4, 2, new Middle('b')),
+            $this->createDomainMessage(4, 3, new Middle('c')),
+            $this->createDomainMessage(4, 4, new Middle('d')),
+            $this->createDomainMessage(4, 5, new End()),
+
+            $this->createDomainMessage(3, 4, new Middle('d')),
+
+            $this->createDomainMessage(1, 5, new End()),
+
+            $this->createDomainMessage(3, 5, new End()),
+        );
+    }
+
+    private function createDomainMessage($id, $playhead, $event)
+    {
+        $id = $this->getId($id);
+        return new DomainMessage((string) $id, (string) $playhead, new Metadata(array()), $event, DateTime::now());
+    }
+
+    private function getId($id)
+    {
+        $uuid = sprintf('%08d-%04d-4%03d-%04d-%012d', $id, $id, $id, $id, $id);
+
+        return $uuid;
+    }
+}
+
+class RecordingEventVisitor implements EventVisitorInterface
+{
+    /**
+     * @var DomainMessage
+     */
+    private $visitedEvents;
+
+    public function doWithEvent(DomainMessage $domainMessage)
+    {
+        $this->visitedEvents[] = $domainMessage;
+    }
+
+    public function getVisitedEvents()
+    {
+        return $this->visitedEvents;
+    }
+
+    public function clearVisitedEvents()
+    {
+        $this->visitedEvents = array();
+    }
+}
+
+class Event implements SerializableInterface
+{
+    public static function deserialize(array $data)
+    {
+        return new static();
+    }
+
+    public function serialize()
+    {
+        return array();
+    }
+}
+
+class Start extends Event
+{
+}
+
+class Middle extends Event
+{
+    public $position;
+    public function __construct($position)
+    {
+        $this->position = $position;
+    }
+
+    public static function deserialize(array $data)
+    {
+        return new static($data['position']);
+    }
+
+    public function serialize()
+    {
+        return array(
+            'position' => $this->position,
+        );
+    }
+}
+
+class End extends Event
+{
+}

--- a/test/Broadway/EventStore/Management/InMemoryEventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/InMemoryEventStoreManagementTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\EventStore\Management;
+
+use Broadway\EventStore\InMemoryEventStore;
+
+class InMemoryEventStoreManagementTest extends EventStoreManagementTest
+{
+    public function createEventStore()
+    {
+        return new InMemoryEventStore();
+    }
+}


### PR DESCRIPTION
This is an alternate implementation to #73. It follows some of the original AxonFramework naming and ideas but does so with a much simpler interface for building and using criteria. Essentially, I'm allowing for filtering/querying just on Aggregate Root Type, Aggregate Root ID, and Event Type.

There is currently no way to actually filter/query based on Aggregate Root Type but I didn't realize that until after it was completely implemented. :) I thought I'd be able to do it for at least the in memory store but nope! I can remove it and put it back in after #181.

```php
$criteria = Criteria::create()->withEventType('Acme.Foo.Event.EatFoo');

$criteria = Criteria::create()->withEventTypes([
    'Acme.Foo.Event.EatFoo',
    'Acme.Foo.Event.CookFoo',
]);

$criteria = Criteria::create()->withEventType('Acme.Foo.Event.EatFoo');

$criteria = Criteria::create()
    ->withAggregateRootId('CA59B2DB-7782-4A63-9304-91DDEBB425E3')
    ->withEventType('Acme.Foo.Event.EatFoo')
;

$eventStore->visitEvents($eventVisitor, $criteria);
```

There are probably some PHP 5.4 `[]` arrays somewhere. Will see once Travis runs. :)

Tests are written for In Memory, DBAL, and DBAL w/ Binary.