### PR TITLE
Properly split configuration for command bus events and logging

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/Configuration.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/Configuration.php
@@ -33,7 +33,20 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('command_handling')
                     ->addDefaultsIfNotSet()
+                    ->beforeNormalization()
+                        ->always(function (array $v) {
+                            if (isset($v['logger']) && $v['logger']) {
+                                // auditing requires event dispatching
+                                $v['dispatch_events'] = true;
+                            }
+
+                            return $v;
+                        })
+                    ->end()
                     ->children()
+                        ->booleanNode('dispatch_events')
+                            ->defaultFalse()
+                        ->end()
                         ->scalarNode('logger')
                             ->defaultFalse()
                         ->end()

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/auditing.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/auditing.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="broadway.auditing.command_logger" class="Broadway\Auditing\CommandLogger">
+            <argument type="service" id="broadway.auditing.logger"/>
+            <argument type="service" id="broadway.auditing.serializer"/>
+            <tag name="broadway.event_listener" event="broadway.command_handling.command_success"
+                 method="onCommandHandlingSuccess"/>
+            <tag name="broadway.event_listener" event="broadway.command_handling.command_failure"
+                 method="onCommandHandlingFailure"/>
+        </service>
+
+        <service id="broadway.auditing.serializer" class="Broadway\Auditing\CommandSerializer"/>
+
+    </services>
+</container>

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/services.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/services.xml
@@ -12,15 +12,6 @@
             <argument type="service" id="broadway.event_dispatcher" />
         </service>
 
-        <service id="broadway.auditing.command_logger" class="Broadway\Auditing\CommandLogger">
-            <argument><!-- logger --></argument>
-            <argument type="service" id="broadway.auditing.serializer" />
-            <tag name="broadway.event_listener" event="broadway.command_handling.command_success" method="onCommandHandlingSuccess" />
-            <tag name="broadway.event_listener" event="broadway.command_handling.command_failure" method="onCommandHandlingFailure" />
-        </service>
-
-        <service id="broadway.auditing.serializer" class="Broadway\Auditing\CommandSerializer" />
-
         <service id="broadway.event_handling.event_bus" class="Broadway\EventHandling\SimpleEventBus"  lazy="true"/>
 
         <service id="broadway.uuid.generator" class="Broadway\UuidGenerator\Rfc4122\Version4Generator" />

--- a/src/Broadway/Bundle/README.md
+++ b/src/Broadway/Bundle/README.md
@@ -77,7 +77,7 @@ broadway:
             table:            events
             use_binary:       false # If you want to use UUIDs to be stored as BINARY(16), required DBAL >= 2.5.0
     command_handling:
-        logger:               false
+        logger:               false # If you want to log every command handled, provide the logger's service id here (e.g. "logger")
     saga:
         repository:           ~ # One of "in_memory"; "mongodb"
     read_model:

--- a/test/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtensionTest.php
+++ b/test/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtensionTest.php
@@ -161,16 +161,30 @@ class BroadwayExtensionTest extends ExtensionTestCase
     /**
      * @test
      */
-    public function it_sets_the_logger_in_the_auditing_command_logger()
+    public function it_creates_an_auditing_logger_alias()
     {
         $configuration = array('command_handling' => array('logger' => 'service'));
 
         $this->load($this->extension, $configuration);
 
-        $loggingCommandBus = $this->container->getDefinition('broadway.auditing.command_logger');
-        $actualReference   = $loggingCommandBus->getArgument(0);
-        $expectedReference = new Reference('service');
-        $this->assertEquals($expectedReference, $actualReference);
+        $auditingLoggerAlias = $this->container->getAlias('broadway.auditing.logger');
+        $this->assertEquals('service', (string) $auditingLoggerAlias);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_enable_the_event_dispatching_command_bus_but_not_the_logger()
+    {
+        $configuration = array('command_handling' => array('dispatch_events' => true, 'logger' => false));
+
+        $this->load($this->extension, $configuration);
+
+        $this->assertSame(
+            'broadway.command_handling.event_dispatching_command_bus',
+            (string) $this->container->getAlias('broadway.command_handling.command_bus')
+        );
+        $this->assertFalse($this->container->hasDefinition('broadway.auditing.command_logger'));
     }
 
     private function assertDICAliasClass($aliasId, $class)


### PR DESCRIPTION
In support of https://github.com/qandidate-labs/broadway/pull/185

First of all: the auditing command logger should only be registered as a service when a logger has been provided. This has been fixed in this PR.

Second: people might be interested in using the event dispatching command bus, but not using the built-in command handler. So I added a configuration option `command_handling.dispatch_events`. This can be:

- `false`: the simple command bus will be used
- `true`: the event dispatching command bus will be used

If a logger has been provided, the `dispatch_events` will be automatically set to `true`, because the `CommandLogger` depends on it.