### PR TITLE
Bugfix: Avoid tagging the saga manager when no sagas are registered

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/BroadwayBundle.php
+++ b/src/Broadway/Bundle/BroadwayBundle/BroadwayBundle.php
@@ -35,6 +35,12 @@ class BroadwayBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(
+            new RegisterSagaCompilerPass(
+                'broadway.saga.multiple_saga_manager',
+                'broadway.saga'
+            )
+        );
+        $container->addCompilerPass(
             new RegisterBusSubscribersCompilerPass(
                 'broadway.command_handling.command_bus',
                 'command_handler',
@@ -62,12 +68,6 @@ class BroadwayBundle extends Bundle
         );
         $container->addCompilerPass(
             new DefineDBALEventStoreConnectionCompilerPass($this->getContainerExtension()->getAlias())
-        );
-        $container->addCompilerPass(
-            new RegisterSagaCompilerPass(
-                'broadway.saga.multiple_saga_manager',
-                'broadway.saga'
-            )
         );
     }
 

--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterSagaCompilerPass.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterSagaCompilerPass.php
@@ -48,8 +48,11 @@ class RegisterSagaCompilerPass implements CompilerPassInterface
             }
         }
 
-        $container
-            ->findDefinition($this->multipleSagaManagerService)
-            ->replaceArgument(1, $sagas);
+        if (count($sagas) > 0) {
+            $container
+                ->findDefinition($this->multipleSagaManagerService)
+                ->replaceArgument(1, $sagas)
+                ->addTag('broadway.domain.event_listener');
+        }
     }
 }

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga.xml
@@ -25,7 +25,6 @@
             <argument type="service" id="broadway.saga.state.state_manager" />
             <argument type="service" id="broadway.saga.metadata.factory" />
             <argument type="service" id="broadway.event_dispatcher" />
-            <tag name="broadway.domain.event_listener" />
         </service>
 
     </services>

--- a/test/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterSagaCompilerPassTest.php
+++ b/test/Broadway/Bundle/BroadwayBundle/DependencyInjection/RegisterSagaCompilerPassTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Broadway\Bundle\BroadwayBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use PHPUnit_Framework_TestCase;
+
+class RegisterSagaCompilerPassTest extends PHPUnit_Framework_TestCase
+{
+    private $compilerPass;
+    private $definition;
+
+    public function setUp()
+    {
+        $this->compilerPass = new RegisterSagaCompilerPass('acme.saga_manager', 'acme.saga');
+
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->setMethods(array('has', 'get', 'findTaggedServiceIds', 'findDefinition'))
+            ->getMock();
+    }
+
+    /**
+     * @test
+     * @expectedException LogicException
+     */
+    public function it_will_throw_for_invalid_service()
+    {
+        $this->container->expects($this->at(0))
+            ->method('has')
+            ->with('acme.saga_manager')
+            ->will($this->returnValue(false));
+
+        $this->compilerPass->process($this->container);
+    }
+
+    /**
+     * @test
+     */
+    public function it_replaces_the_sagas_in_the_saga_manager()
+    {
+        $this->mockDefinition();
+
+        $this->container->expects($this->once())
+            ->method('findtaggedserviceids')
+            ->with('acme.saga')
+            ->will($this->returnvalue(array(
+                'acme.sample_saga' => array('acme.saga' => array('type' => 'my_saga'))
+            )));
+
+        $this->definition->expects($this->once())
+            ->method('replaceArgument')
+            ->with(1, array('my_saga' => new Reference('acme.sample_saga')))
+            ->will($this->returnSelf());
+
+        $this->compilerPass->process($this->container);
+    }
+
+    /**
+     * @test
+     */
+    public function it_doesnt_register_the_manager_when_no_sagas_registered()
+    {
+        $this->mockDefinition();
+
+        $this->container->expects($this->once())
+            ->method('findtaggedserviceids')
+            ->with('acme.saga')
+            ->will($this->returnvalue(array()));
+
+        $this->definition->expects($this->never())
+            ->method('replaceArgument');
+
+        $this->definition->expects($this->never())
+            ->method('addTag');
+
+        $this->compilerPass->process($this->container);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_the_domain_listener_tag()
+    {
+        $this->mockDefinition();
+
+        $this->container->expects($this->once())
+            ->method('findtaggedserviceids')
+            ->with('acme.saga')
+            ->will($this->returnvalue(array(
+                'acme.sample_saga' => array('acme.saga' => array('type' => 'my_saga'))
+            )));
+
+        $this->definition->expects($this->once())
+            ->method('replaceArgument')
+            ->will($this->returnSelf());
+
+        $this->definition->expects($this->once())
+            ->method('addTag')
+            ->with('broadway.domain.event_listener');
+
+        $this->compilerPass->process($this->container);
+    }
+
+    private function mockDefinition()
+    {
+        $this->container->expects($this->any())
+            ->method('has')
+            ->will($this->returnValue(true));
+
+        $this->definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->container->expects($this->any())
+            ->method('findDefinition')
+            ->will($this->returnValue($this->definition));
+    }
+}


### PR DESCRIPTION
Fixes #197 

As the `MultipleSagaManager` was registered to the event bus, the mongo connection turned into a hard requirement.
This PR fixes that requirement by only tagging the manager if there are actual sagas registered.