### PR TITLE
Add associative keys to event arguments in EventDispatchingCommandBus

### DIFF
--- a/src/Broadway/CommandHandling/EventDispatchingCommandBus.php
+++ b/src/Broadway/CommandHandling/EventDispatchingCommandBus.php
@@ -43,7 +43,10 @@ class EventDispatchingCommandBus implements CommandBusInterface
             $this->commandBus->dispatch($command);
             $this->dispatcher->dispatch(self::EVENT_COMMAND_SUCCESS, array('command' => $command));
         } catch (Exception $e) {
-            $this->dispatcher->dispatch(self::EVENT_COMMAND_FAILURE, array($command, $e));
+            $this->dispatcher->dispatch(
+                self::EVENT_COMMAND_FAILURE,
+                array('command' => $command, 'exception' => $e)
+            );
 
             throw $e;
         }

--- a/test/Broadway/CommandHandling/EventDispatchingCommandBusTest.php
+++ b/test/Broadway/CommandHandling/EventDispatchingCommandBusTest.php
@@ -61,7 +61,10 @@ class EventDispatchingCommandBusTest extends TestCase
         $exception = new MyException();
         $this->eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(EventDispatchingCommandBus::EVENT_COMMAND_FAILURE, array($this->command, $exception));
+            ->with(
+                EventDispatchingCommandBus::EVENT_COMMAND_FAILURE,
+                array('command' => $this->command, 'exception' => $exception)
+            );
 
         $this->baseCommandBus->expects($this->once())
             ->method('dispatch')


### PR DESCRIPTION
This pull request adds associative keys to arguments in command failure event in EventDispatchingCommandBus to make it consistent with command success event