### PR TITLE
Upped the minimal required PHP version to 5.5.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
 
 matrix:
     include:
-        - php: 5.3
-        - php: 5.4
         - php: 5.5
         - php: 5.6
           env: COMPOSER_LOWEST=""

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "beberlei/assert": "~2.0",
         "broadway/uuid-generator": "~0.1.0",
-        "php": ">=5.3.3",
+        "php": ">=5.5.9",
         "ramsey/uuid": "~2.4"
     },
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f5b9cc480c35672d7896e97b25dbb505",
+    "hash": "220f06ffa2e292e94f62a6b9b3f6f128",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -89,16 +89,16 @@
             "time": "2014-09-12 14:14:07"
         },
         {
-            "name": "rhumsaa/uuid",
+            "name": "ramsey/uuid",
             "version": "2.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ramsey/rhumsaa-uuid.git",
+                "url": "https://github.com/ramsey/uuid.git",
                 "reference": "cca98c652cac412c9c2f109c69e5532f313435fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/rhumsaa-uuid/zipball/cca98c652cac412c9c2f109c69e5532f313435fc",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/cca98c652cac412c9c2f109c69e5532f313435fc",
                 "reference": "cca98c652cac412c9c2f109c69e5532f313435fc",
                 "shasum": ""
             },
@@ -1432,6 +1432,72 @@
             "time": "2012-12-21 11:40:51"
         },
         {
+            "name": "rhumsaa/uuid",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/rhumsaa-uuid.git",
+                "reference": "cca98c652cac412c9c2f109c69e5532f313435fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/rhumsaa-uuid/zipball/cca98c652cac412c9c2f109c69e5532f313435fc",
+                "reference": "cca98c652cac412c9c2f109c69e5532f313435fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "doctrine/dbal": ">=2.3",
+                "moontoast/math": "~1.1",
+                "phpunit/phpunit": "~4.1",
+                "satooshi/php-coveralls": "~0.6",
+                "symfony/console": "~2.3"
+            },
+            "suggest": {
+                "doctrine/dbal": "Allow the use of a UUID as doctrine field type.",
+                "moontoast/math": "Support for converting UUID to 128-bit integer (in string form).",
+                "symfony/console": "Support for use of the bin/uuid command line tool."
+            },
+            "bin": [
+                "bin/uuid"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Rhumsaa\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Ben Ramsey",
+                    "homepage": "http://benramsey.com"
+                }
+            ],
+            "description": "A PHP 5.3+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2014-11-09 18:42:56"
+        },
+        {
             "name": "symfony/asset",
             "version": "v2.7.1",
             "source": {
@@ -2738,7 +2804,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.5.9"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
We got requested this a lot, so it's about time :boom: 

I hope nobody still depends on 5.4 or lower...

5.5.9 because:
- Ubuntu LTS [ships with 5.5.9](https://launchpad.net/ubuntu/trusty/+source/php5)
- [Travis doesn't support lower](http://docs.travis-ci.com/user/languages/php/#Choosing-PHP-versions-to-test-against)
- [Symfony 3.0 requires it](https://github.com/symfony/symfony/blob/11de7b3996477fb5361b5c7a70e41e2298d2e4ab/composer.json#L19)