### PR TITLE
Factory definitions in extension

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
@@ -122,7 +122,7 @@ class BroadwayExtension extends Extension
 
     private function loadFactory(ContainerBuilder $container, $service, $factoryService, $factoryMethod)
     {
-        $definition = $container->get($service);
+        $definition = $container->getDefinition($service);
 
         if (method_exists($definition, 'setFactory')) {
             $definition->setFactory(array(new Reference($factoryService), $factoryMethod));

--- a/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
+++ b/src/Broadway/Bundle/BroadwayBundle/DependencyInjection/BroadwayExtension.php
@@ -94,6 +94,21 @@ class BroadwayExtension extends Extension
 
                 $container->setParameter('broadway.saga.mongodb.storage_suffix', (string) $config['mongodb']['storage_suffix']);
                 $container->setParameter('broadway.saga.mongodb.database', $database);
+
+                // Required until minimum support bumped to 2.6, then to be inlined in sage/mongodb.xml
+                $this->loadFactory(
+                    $container,
+                    'broadway.saga.state.mongodb_database',
+                    'broadway.saga.state.mongodb_connection',
+                    'selectDatabase'
+                );
+                $this->loadFactory(
+                    $container,
+                    'broadway.saga.state.mongodb_collection',
+                    'broadway.saga.state.mongodb_database',
+                    'createCollection'
+                );
+
                 break;
             case 'in_memory':
                 $loader->load('saga/in_memory.xml');
@@ -102,6 +117,18 @@ class BroadwayExtension extends Extension
                     'broadway.saga.state.in_memory_repository'
                 );
                 break;
+        }
+    }
+
+    private function loadFactory(ContainerBuilder $container, $service, $factoryService, $factoryMethod)
+    {
+        $definition = $container->get($service);
+
+        if (method_exists($definition, 'setFactory')) {
+            $definition->setFactory(array(new Reference($factoryService), $factoryMethod));
+        } else {
+            $definition->setFactoryService($factoryService);
+            $definition->setFactoryMethod($factoryMethod);
         }
     }
 

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
@@ -9,24 +9,22 @@
             <argument type="service" id="broadway.saga.state.mongodb_collection" />
         </service>
 
-        <service id="broadway.saga.state.mongodb_database"
-                 class           = "Doctrine\MongoDB\Database"
-                 factory-service = "broadway.saga.state.mongodb_connection"
-                 factory-method  = "selectDatabase"
-                >
+        <service id="broadway.saga.state.mongodb_database" class="Doctrine\MongoDB\Database">
+            <!--
+            Set in BroadwayExtension until minimum support bumped to 2.6
+            <factory service="broadway.saga.state.mongodb_connection" method="selectDatabase" />
+            -->
             <argument>%broadway.saga.mongodb.database%</argument>
         </service>
 
         <service id="broadway.saga.state.mongodb_connection" class="Doctrine\MongoDB\Connection">
-            <argument>null</argument>
-            <argument type="collection" />
         </service>
 
-        <service id="broadway.saga.state.mongodb_collection"
-                 class           = "Doctrine\MongoDB\Collection"
-                 factory-service = "broadway.saga.state.mongodb_database"
-                 factory-method  = "createCollection"
-                >
+        <service id="broadway.saga.state.mongodb_collection" class="Doctrine\MongoDB\Collection">
+            <!--
+            Set in BroadwayExtension until minimum support bumped to 2.6
+            <factory service="broadway.saga.state.mongodb_database" method="createCollection" />
+            -->
             <argument>saga-state</argument>
         </service>
 

--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
@@ -18,6 +18,8 @@
         </service>
 
         <service id="broadway.saga.state.mongodb_connection" class="Doctrine\MongoDB\Connection">
+            <argument>null</argument>
+            <argument type="collection" />
         </service>
 
         <service id="broadway.saga.state.mongodb_collection" class="Doctrine\MongoDB\Collection">


### PR DESCRIPTION
Moved the factory definitions to the extension so that they can be set correctly before and after the change in `symfony/dependency-injection` 2.6.