### PR TITLE
Change DateTime to be locale agnostic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ matrix:
           env: COMPOSER_LOWEST="--prefer-lowest"
     fast_finish: true
 
+addons:
+    apt:
+        packages:
+            - language-pack-fr
+            - language-pack-en
+
 before_install:
     - echo "extension=mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/src/Broadway/Domain/DateTime.php
+++ b/src/Broadway/Domain/DateTime.php
@@ -37,7 +37,7 @@ class DateTime
         return new DateTime(
             BaseDateTime::createFromFormat(
                 'U.u',
-                sprintf('%.6f', microtime(true)),
+                sprintf('%.6F', microtime(true)),
                 new DateTimeZone('UTC')
             )
         );

--- a/test/Broadway/Domain/DateTimeTest.php
+++ b/test/Broadway/Domain/DateTimeTest.php
@@ -40,8 +40,8 @@ class DateTimeTest extends TestCase
     public function providesLocales()
     {
         return array(
-            array('en_GB'),
-            array('fr_FR'),
+            array('en_GB.UTF-8'),
+            array('fr_FR.UTF-8'),
         );
     }
 

--- a/test/Broadway/Domain/DateTimeTest.php
+++ b/test/Broadway/Domain/DateTimeTest.php
@@ -28,10 +28,21 @@ class DateTimeTest extends TestCase
 
     /**
      * @test
+     * @dataProvider providesLocales
      */
-    public function it_creates_now()
+    public function it_creates_now($locale)
     {
+        setlocale(LC_ALL, $locale);
+
         $this->assertInstanceOf('Broadway\Domain\DateTime', DateTime::now());
+    }
+
+    public function providesLocales()
+    {
+        return array(
+            array('en_GB'),
+            array('fr_FR'),
+        );
     }
 
     /**

--- a/test/Broadway/Domain/DateTimeTest.php
+++ b/test/Broadway/Domain/DateTimeTest.php
@@ -32,7 +32,7 @@ class DateTimeTest extends TestCase
      */
     public function it_creates_now($locale)
     {
-        setlocale(LC_ALL, $locale);
+        $this->setLocale(LC_ALL, $locale);
 
         $this->assertInstanceOf('Broadway\Domain\DateTime', DateTime::now());
     }


### PR DESCRIPTION
`sprintf('%.6f', $float)` is locale aware. When trying to convert a float to a server with locale set to `'fr_FR'` for example, the result string has `,` inside as a decimal separator.

This leads to `DateTime::createFromFormat()` to fail as it expects `.` instead.