### PR TITLE
Bundle is now Symfony 3 compatible

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
+++ b/src/Broadway/Bundle/BroadwayBundle/Resources/config/saga/mongodb.xml
@@ -9,11 +9,8 @@
             <argument type="service" id="broadway.saga.state.mongodb_collection" />
         </service>
 
-        <service id="broadway.saga.state.mongodb_database"
-                 class           = "Doctrine\MongoDB\Database"
-                 factory-service = "broadway.saga.state.mongodb_connection"
-                 factory-method  = "selectDatabase"
-                >
+        <service id="broadway.saga.state.mongodb_database" class="Doctrine\MongoDB\Database">
+            <factory service="broadway.saga.state.mongodb_connection" method="selectDatabase" />
             <argument>%broadway.saga.mongodb.database%</argument>
         </service>
 
@@ -22,11 +19,8 @@
             <argument type="collection" />
         </service>
 
-        <service id="broadway.saga.state.mongodb_collection"
-                 class           = "Doctrine\MongoDB\Collection"
-                 factory-service = "broadway.saga.state.mongodb_database"
-                 factory-method  = "createCollection"
-                >
+        <service id="broadway.saga.state.mongodb_collection" class="Doctrine\MongoDB\Collection">
+            <factory service="broadway.saga.state.mongodb_database" method="createCollection" />
             <argument>saga-state</argument>
         </service>
 


### PR DESCRIPTION
To use the bundle with Symfony 3 I had to remove some deprecated configuration options: <code>factory-class</code>, <code>factory-method</code>, <code>factory-service</code>.

These are deprecated since 2.6. 