### PR TITLE
Added thenEventExists to CommandHandling Scenario 

### DIFF
--- a/src/Broadway/CommandHandling/Testing/Scenario.php
+++ b/src/Broadway/CommandHandling/Testing/Scenario.php
@@ -106,4 +106,15 @@ class Scenario
 
         return $this;
     }
+    /**
+     * @param $event
+     *
+     * @return Scenario
+     */
+    public function thenEventExists($event)
+    {
+        $this->testCase->assertContains($event, $this->eventStore->getEvents(), '', false, false);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
By using thenEventExists, instead of checking for all events we can check for particular event if was dispatched by running a command.

I was thinking of just extending the current class but cant access testCase (it's private)