### PR TITLE
Update EventStreamNotFoundException  add tablename

### DIFF
--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -84,7 +84,7 @@ class DBALEventStore implements EventStoreInterface, EventStoreManagementInterfa
         }
 
         if (empty($events)) {
-            throw new EventStreamNotFoundException(sprintf('EventStream not found for aggregate with id %s', $id));
+            throw new EventStreamNotFoundException(sprintf('EventStream not found for aggregate with id %s for table %s', $id, $this->tableName));
         }
 
         return new DomainEventStream($events);


### PR DESCRIPTION
I'm using different event tables for different parts of my site. So having a bit more info in the exception is quite helpful.