### PR TITLE
Add ReflectionAggregateFactory

### DIFF
--- a/src/Broadway/EventSourcing/AggregateFactory/ReflectionAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/ReflectionAggregateFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Broadway\EventSourcing\AggregateFactory;
+
+use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+use LogicException;
+use ReflectionClass;
+
+/**
+ * Creates aggregates with reflection without constructor.
+ */
+final class ReflectionAggregateFactory implements AggregateFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream)
+    {
+        $class = new ReflectionClass($aggregateClass);
+        $aggregate = $class->newInstanceWithoutConstructor();
+
+        if (!$aggregate instanceof EventSourcedAggregateRoot) {
+            throw new LogicException(sprintf('Impossible to initialize "%s"', $aggregateClass));
+        }
+
+        $aggregate->initializeState($domainEventStream);
+
+        return $aggregate;
+    }
+}

--- a/test/Broadway/EventSourcing/AggregateFactory/ReflectionAggregateFactoryTest.php
+++ b/test/Broadway/EventSourcing/AggregateFactory/ReflectionAggregateFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Broadway\EventSourcing\AggregateFactory;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\EventSourcing\EventSourcedAggregateRoot;
+use Broadway\TestCase;
+
+/**
+ *
+ */
+final class ReflectionAggregateFactoryTest extends TestCase
+{
+    /**
+     * @var ReflectionAggregateFactory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->factory = new ReflectionAggregateFactory();
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_instance_of_aggregate_with_private_constructor()
+    {
+        $aggregate = $this->factory->create(
+            TestAggregateWithPrivateConstructor::class,
+            new DomainEventStream([])
+        );
+
+        $this->assertInstanceOf(TestAggregateWithPrivateConstructor::class, $aggregate);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_instance_of_aggregate_with_public_constructor()
+    {
+        $aggregate = $this->factory->create(
+            TestAggregateWithPublicConstructor::class,
+            new DomainEventStream([])
+        );
+
+        $this->assertInstanceOf(TestAggregateWithPublicConstructor::class, $aggregate);
+    }
+
+    /**
+     * @test
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Impossible to initialize "stdClass"
+     */
+    public function it_does_not_handle_weird_classes()
+    {
+        $this->factory->create(\stdClass::class, new DomainEventStream([]));
+    }
+}
+
+final class TestAggregateWithPrivateConstructor extends EventSourcedAggregateRoot
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAggregateRootId()
+    {
+        return 'foo42';
+    }
+}
+
+final class TestAggregateWithPublicConstructor extends EventSourcedAggregateRoot
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getAggregateRootId()
+    {
+        return 'foo42';
+    }
+}


### PR DESCRIPTION
Hi,

In this PR I've added factory which doesn't call constructor. There is already similar factory `NamedConstructorAggregateFactory`, but I don't like it for 2 reasons:
* it forces to have technical named constructor in my shiny model;
* that technical constructor calls regular constructor; but in my opinion it's better to call regular one only when entity's lifecycle starts, but reconstitution is not start of lifecycle.

