### PR TITLE
Ability to extend ReflectionSerializer

### DIFF
--- a/src/Broadway/Serializer/ReflectionSerializer.php
+++ b/src/Broadway/Serializer/ReflectionSerializer.php
@@ -25,7 +25,7 @@ class ReflectionSerializer implements Serializer
         return $this->serializeObjectRecursively($object);
     }
 
-    private function serializeValue($value)
+    protected function serializeValue($value)
     {
         if (is_object($value)) {
             return $this->serializeObjectRecursively($value);
@@ -76,7 +76,7 @@ class ReflectionSerializer implements Serializer
         return $this->deserializeObjectRecursively($serializedObject);
     }
 
-    private function deserializeValue($value)
+    protected function deserializeValue($value)
     {
         if (is_array($value) && isset($value['class']) && isset($value['payload'])) {
             return $this->deserializeObjectRecursively($value);


### PR DESCRIPTION
ReflectionSerializer::serializeValue and ReflectionSerializer::deserializeValue must have the modifier “protected” to be extensible.
For example, to customize serialize/deserialize processes for some objects (like \DateTimeInterface - ReflectionSerialzie can't handle them properly).